### PR TITLE
Enable buildah on Codewind

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -65,9 +65,7 @@ spec:
       - name: shared-workspace
         persistentVolumeClaim:
           claimName: PVC_NAME_PLACEHOLDER
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
+      - name: buildah-volume
       - name: registry-secret
         secret:
           defaultMode: 0777
@@ -82,8 +80,8 @@ spec:
         - name: shared-workspace
           mountPath: /codewind-workspace
           subPath: "WORKSPACE_ID_PLACEHOLDER/projects"
-        - name: dockersock
-          mountPath: "/var/run/docker.sock"
+        - name: buildah-volume
+          mountPath: "/var/lib/containers"
         - name: registry-secret
           mountPath: "/tmp/secret"
         env:


### PR DESCRIPTION
Removes the old Docker socket mount as it's no longer needed, and replacing it with an emptyDir buildah volume, enabling Codewind to use buildah on Kubernetes