### PR TITLE
Add owner references to ensure PFE deletion after workspace deletion

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -40,7 +40,13 @@ metadata:
   labels:
     app: codewind-pfe
     workspace: WORKSPACE_ID_PLACEHOLDER
-
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: OWNER_REFERENCE_NAME_PLACEHOLDER
+      uid: OWNER_REFERENCE_UID_PLACEHOLDER
 spec:
   selector:
     matchLabels:
@@ -51,13 +57,6 @@ spec:
       labels:
         app: codewind-pfe
         workspace: WORKSPACE_ID_PLACEHOLDER
-      ownerReferences:
-        - apiVersion: apps/v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: ReplicaSet
-          name: OWNER_REFERENCE_NAME_PLACEHOLDER
-          uid: OWNER_REFERENCE_UID_PLACEHOLDER
       annotations:
         productName: "codewind"
         productID: "codewind"

--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -17,6 +17,13 @@ metadata:
   labels:
     app: codewind-pfe
     workspace: WORKSPACE_ID_PLACEHOLDER
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: OWNER_REFERENCE_NAME_PLACEHOLDER
+      uid: OWNER_REFERENCE_UID_PLACEHOLDER
 spec:
   ports:
     - port: 9191
@@ -44,6 +51,13 @@ spec:
       labels:
         app: codewind-pfe
         workspace: WORKSPACE_ID_PLACEHOLDER
+      ownerReferences:
+        - apiVersion: apps/v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ReplicaSet
+          name: OWNER_REFERENCE_NAME_PLACEHOLDER
+          uid: OWNER_REFERENCE_UID_PLACEHOLDER
       annotations:
         productName: "codewind"
         productID: "codewind"
@@ -138,6 +152,3 @@ spec:
           limits:
             memory: 2Gi
             cpu: 500m
-
-
----

--- a/codewind-che-sidecar/scripts/kube/deployPFE.sh
+++ b/codewind-che-sidecar/scripts/kube/deployPFE.sh
@@ -62,5 +62,12 @@ fi
 echo "Patching the service account with the registry secret"
 kubectl patch serviceaccount $WORKSPACE_SERVICE_ACCOUNT -p "{\"imagePullSecrets\": [{\"name\": \"$REGISTRY_SECRET\"}]}"
 
+# Set the owner reference to ensure clean up
+OWNER_REFERENCE_NAME=$( kubectl get po --selector=che.original_name=che-workspace-pod,che.workspace_id=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.ownerReferences[0].name}' )
+sed -i "s/OWNER_REFERENCE_NAME_PLACEHOLDER/$OWNER_REFERENCE_NAME/g" /scripts/kube/codewind_template.yaml
+
+OWNER_REFERENCE_UID=$( kubectl get po --selector=che.original_name=che-workspace-pod,che.workspace_id=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.ownerReferences[0].uid}' )
+sed -i "s/OWNER_REFERENCE_UID_PLACEHOLDER/$OWNER_REFERENCE_UID/g" /scripts/kube/codewind_template.yaml
+
 echo "Creating the Codewind deployment and service"
 sed "s/KUBE_NAMESPACE_PLACEHOLDER/$NAMESPACE/g" /scripts/kube/codewind_template.yaml | kubectl apply -f -

--- a/codewind-che-sidecar/scripts/kube/deployPFE.sh
+++ b/codewind-che-sidecar/scripts/kube/deployPFE.sh
@@ -62,7 +62,7 @@ fi
 echo "Patching the service account with the registry secret"
 kubectl patch serviceaccount $WORKSPACE_SERVICE_ACCOUNT -p "{\"imagePullSecrets\": [{\"name\": \"$REGISTRY_SECRET\"}]}"
 
-# Set the owner reference to ensure clean up
+# Set the owner reference to the same owner of the che workspace pod to ensure Codewind resources are cleaned up when the workspace is deleted
 OWNER_REFERENCE_NAME=$( kubectl get po --selector=che.original_name=che-workspace-pod,che.workspace_id=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.ownerReferences[0].name}' )
 sed -i "s/OWNER_REFERENCE_NAME_PLACEHOLDER/$OWNER_REFERENCE_NAME/g" /scripts/kube/codewind_template.yaml
 


### PR DESCRIPTION
Kubernetes has a garbage collection controller. It works by inspecting the owner references for resources. If Resource B is owned by Resource A and a delete is issued to Resource A then Resource B will be cleaned up by the controller along with Resource A.

We can use the garbage collection mechanism to our advantage by adding owner references to the Codewind resources when they are created so that their owner is the same as the Workspace Pod's owner. (The ReplicaSet) Then when a user deletes the workspace the che workspace deployment is deleted which will trigger deletion on all resources owned by it and handle the deletion in a cascading fashion. I've tested this with the PFE deployments and this works well and doesn't require additional code in Codewind for handling cleanup on workspace deletion.
More details: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/