### PR TITLE
Add replicaset/finalizers to codewind roles

### DIFF
--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -64,8 +64,8 @@ rules:
   resources: ["deployments"]
   verbs: ["watch", "get", "list", "create", "update", "delete"]
 
-- apiGroups: ["extensions"]
-  resources: ["replicasets"]
+- apiGroups: ["extensions", "apps"]
+  resources: ["replicasets", "replicasets/finalizers"]
   verbs: ["get", "list", "update", "delete"]
 
 - apiGroups: ["apiextensions.k8s.io"]

--- a/setup/install_che/install.sh
+++ b/setup/install_che/install.sh
@@ -93,7 +93,7 @@ else
         --set global.cheWorkspacesNamespace=$CHE_NAMESPACE \
         --set global.cheWorkspaceClusterRole=eclipse-codewind \
         --set che.workspace.devfileRegistryUrl="https://che-devfile-registry.openshift.io/" \
-        --set che.workspace.pluginRegistryUrl="https://che-plugin-registry.openshift.io/v3" --tls ./
+        --set che.workspace.pluginRegistryUrl="https://che-plugin-registry.openshift.io/v3" ./
     
     kubectl apply -f ${BASE_DIR}/codewind-rolebinding.yaml -n $CHE_NAMESPACE
 fi


### PR DESCRIPTION
On OKD and OpenShift, the default cluster role was unable to create the finalizers for deployments and services, as verbs for the `replicaset/finalizer` resource were missing from the Codewind cluster role. This PR adds them in.

Signed-off-by: John Collier <John.J.Collier@ibm.com>