### PR TITLE
Add env vars for owner refs

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -142,6 +142,10 @@ spec:
             value: /projects
           - name: EXTRA_GIT_OPTION
             value: ""
+          - name: OWNER_REF_NAME
+            value: OWNER_REFERENCE_NAME_PLACEHOLDER
+          - name: OWNER_REF_UID
+            value: OWNER_REFERENCE_UID_PLACEHOLDER
         ports:
         - containerPort: 9191
         resources:


### PR DESCRIPTION
Adds environment variables to the codewind deployment so that they can be used for the user's project resources as well.

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>