### PR TITLE
Add ability to get failure statuses of missing keys in template or any other deployment failures

### DIFF
--- a/codewind-che-sidecar/Dockerfile
+++ b/codewind-che-sidecar/Dockerfile
@@ -53,6 +53,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
+RUN apk update && apk add jq 
+
 COPY scripts/ /scripts
 
 RUN chmod -R g+rwx /scripts && chown -R www-data:root /scripts

--- a/codewind-che-sidecar/scripts/kube/deployPFE.sh
+++ b/codewind-che-sidecar/scripts/kube/deployPFE.sh
@@ -89,8 +89,10 @@ fi
 # Set the Docker registry secret
 kubectl get secret $CHE_WORKSPACE_ID-private-registries > /dev/null 2>&1
 if [[ $? != 0 ]]; then
-    echo "Unable to find Che docker registry secret. PFE deployment may fail."
-    echo "Please create a secret via the Che dashboard."
+    message="Unable to find Che docker registry secret. PFE deployment may fail. Please create a secret via the Che dashboard."
+    echo "$message"
+    key=DOCKER_REGISTRY_SECRET_NOT_FOUND
+    updateDeployStatus $key $DEPLOY_STATUS_FILE $message
 else
     REGISTRY_SECRET=$CHE_WORKSPACE_ID-private-registries
     echo "Setting the registry secret"


### PR DESCRIPTION
# Description

We want the ability to know failure related to either a poor formatted sidecar template file or missing keys that could not be easily replaced and as a result the deployment failed.

This PR adds a utility to include failure statuses and store in a json file that can be later used by the editor clients. 

The utility can be used to store any failure (i.e even kubectl command failures) but for now I only have them on failing to update the template file with a custom message as well. It can also hand piped command failures.

Issue: https://github.ibm.com/dev-ex/iterative-dev/issues/1077