### PR TITLE
Rename codewind deployment and service names

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -13,7 +13,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: codewind-release-WORKSPACE_ID_PLACEHOLDER
+  name: codewind-WORKSPACE_ID_PLACEHOLDER
   labels:
     app: codewind-pfe
     workspace: WORKSPACE_ID_PLACEHOLDER
@@ -36,7 +36,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: codewind-release-WORKSPACE_ID_PLACEHOLDER
+  name: codewind-WORKSPACE_ID_PLACEHOLDER
   labels:
     app: codewind-pfe
     workspace: WORKSPACE_ID_PLACEHOLDER
@@ -110,8 +110,6 @@ spec:
             value: "WORKSPACE_ID_PLACEHOLDER"
           - name: PVC_NAME
             value: PVC_NAME_PLACEHOLDER
-          - name: FULL_NAME
-            value: codewind-release
           - name: LOADRUNNER_IMAGE
             value: ibmcom/microclimate-loadrunner:1903
           - name: LOADRUNNER_MEM_REQUEST
@@ -123,7 +121,7 @@ spec:
           - name: LOADRUNNER_CPU_LIMIT
             value: 1000m
           - name: SERVICE_NAME
-            value: codewind-release
+            value: codewind-WORKSPACE_ID_PLACEHOLDER
           - name: DOCKER_REGISTRY_SECRET
             value: "REGISTRY_SECRET_PLACEHOLDER"
           - name: DOCKER_REGISTRY_URL


### PR DESCRIPTION
Renames the deployment and service prefix for the pfe deployment from `codewind-release` to just `codewind`.

@tobespc Shouldn't break portal code, didn't find any references to `FULL_NAME` in the portal code and the wrong value was actually being set for `SERVICE_NAME`. I've corrected that in this PR. However, appears the existing code that uses `SERVICE_NAME` needs updating currently because it tries to look up the pfe ingress, however there currently isn't one because pfe isn't exposed outside of the cluster at this point in time.

Relevant section of code from portal:
```
  try {
    k8Client = new K8Client({ config: k8config.getInCluster(), version: '1.9' });
    if (k8Client) {
      log.info('codewind on Kubernetes');
      global.codewind.RUNNING_IN_K8S = true;

      // get path currently running on
      const k8sServiceName = process.env.SERVICE_NAME;
      const k8sNameSpace = process.env.KUBE_NAMESPACE || 'default';
      let currentIngress = await k8Client.apis.extensions.v1beta1.namespaces(k8sNameSpace).ingress(k8sServiceName).get();
      let k8sIngressPath = currentIngress.body.spec.rules[0].host;
      const protocol = process.env.PORTAL_HTTPS == 'true' ? 'https://' : 'http://'
      originsWhitelist.push(protocol + k8sIngressPath);
    }
  } catch (err) {
    // Not in K8s
    log.info('codewind on Docker');
    originsWhitelist.push('http://localhost:*');
  }
```

It'll currently reach the line to get the ingress and then throw to the catch block so the logs end up showing:
```
> codewind-portal@1.0.0 start /portal
> node server.js

[20/06/19 22:48:24 server.js] [INFO] codewind on Kubernetes
[20/06/19 22:48:24 server.js] [INFO] codewind on Docker
[INFO Thu Jun 20 22:48:26 GMT 2019 | FileWatcher] Initialize application state map
[INFO Thu Jun 20 22:48:26 GMT 2019 | FileWatcher] Initialize build state map
```

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>