### PR TITLE
Add container workspace environment variable

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -138,6 +138,8 @@ spec:
             value: "10"
           - name: HOST_WORKSPACE_DIRECTORY
             value: /projects
+          - name: CONTAINER_WORKSPACE_DIRECTORY
+            value: /codewind-workspace
           - name: EXTRA_GIT_OPTION
             value: ""
           - name: OWNER_REF_NAME


### PR DESCRIPTION
On Kube, we need to add container workspace env var for creating .log dir for application cache log and all other logs (eg. docker.build.log, maven.build.log etc). We already implemented the same thing on Local.