### PR TITLE
Add workspace ID selector to PFE

### DIFF
--- a/codewind-che-sidecar/scripts/entrypoint.sh
+++ b/codewind-che-sidecar/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ if [ $? -ne 0 ]; then
     kubectl get svc
 fi
 
-CWServiceName=$(kubectl get svc --selector=app=codewind-pfe,workspace=$CHE_WORKSPACE_ID -o jsonpath="{.items[0].metadata.name}" 2> /dev/null)
+CWServiceName=$(kubectl get svc --selector=app=codewind-pfe,pfeWorkspace=$CHE_WORKSPACE_ID -o jsonpath="{.items[0].metadata.name}" 2> /dev/null)
 if [ -z $CWServiceName ]; then
     echo "ERROR: The Codewind service was not found. Aborting..."
     exit 1

--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -30,6 +30,7 @@ spec:
       name: portal-http
   selector:
     app: codewind-pfe
+    workspace: WORKSPACE_ID_PLACEHOLDER
 
 ---
 

--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -16,7 +16,7 @@ metadata:
   name: codewind-WORKSPACE_ID_PLACEHOLDER
   labels:
     app: codewind-pfe
-    workspace: WORKSPACE_ID_PLACEHOLDER
+    pfeWorkspace: WORKSPACE_ID_PLACEHOLDER
   ownerReferences:
     - apiVersion: apps/v1
       blockOwnerDeletion: true
@@ -29,8 +29,7 @@ spec:
     - port: 9191
       name: portal-http
   selector:
-    app: codewind-pfe
-    workspace: WORKSPACE_ID_PLACEHOLDER
+    pfeWorkspace: WORKSPACE_ID_PLACEHOLDER
 
 ---
 
@@ -57,7 +56,7 @@ spec:
     metadata:
       labels:
         app: codewind-pfe
-        workspace: WORKSPACE_ID_PLACEHOLDER
+        pfeWorkspace: WORKSPACE_ID_PLACEHOLDER
       annotations:
         productName: "codewind"
         productID: "codewind"


### PR DESCRIPTION
Renames the workspace selector in PFE to `pfeWorkspace`, to be more distinct. Also updates the Codewind/PFE service pod selector to use the `pfeWorkspace` pod selector, rather than app.