### PR TITLE
Use eclipse.org download for VS Code extension

### DIFF
--- a/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.0.1/meta.yaml
@@ -24,4 +24,4 @@ firstPublicationDate: "2019-05-30"
 latestUpdateDate: "2019-05-30"
 spec:
   extensions:
-    - http://download.eclipse.org/codewind/codewind-vscode/master/3/codewind-0.2.0-theia_2019-06-24-1937.vsix
+    - https://download.eclipse.org/codewind/codewind-vscode/master/3/codewind-0.2.0-theia_2019-06-24-1937.vsix

--- a/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.0.1/meta.yaml
@@ -24,4 +24,4 @@ firstPublicationDate: "2019-05-30"
 latestUpdateDate: "2019-05-30"
 spec:
   extensions:
-    - https://raw.githubusercontent.com/johnmcollier/devfiles/master/theia/codewind-0.2.0.vsix
+    - http://download.eclipse.org/codewind/codewind-vscode/master/3/codewind-0.2.0-theia_2019-06-24-1937.vsix


### PR DESCRIPTION
Removes the link to my personal Git repo containing the VS Code extension for Theia, and changes it to the official eclipse download link

**Note:** This will change to the release image of the extension later this week.