### PR TITLE
Remove internal IBM links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 	
-	You can contribute to the Codewind project. [Visit us on Slack](https://slack-invite-ibm-cloud-tech.mybluemix.net/) if you have any questions.
+	You can contribute to the Codewind project. [Visit us on Mattermost](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind) if you have any questions.
 	
 	Contributions must follow the Eclipse organization specifications. See the [Git commit instructions](https://www.eclipse.org/projects/handbook/#resources-commit).
 	
 	## Raising issues
 	
-	If you identified a problem or have a feature request, please check the [issues](https://github.ibm.com/dev-ex/codewind-che-plugin/issues) to see if your issue has already been raised. If you do not see your issue, open a new one.
+	If you identified a problem or have a feature request, please check the [issues](https://github.com/eclipse/codewind-che-plugin/issues) to see if your issue has already been raised. If you do not see your issue, open a new one.
 	
 	Please provide context so that we can understand the problem and try to recreate the issue.

--- a/codewind-che-sidecar/Dockerfile
+++ b/codewind-che-sidecar/Dockerfile
@@ -12,14 +12,9 @@
 # First use this layer to build the go version of filewatcherd
 FROM golang:1.12 as builder
 
-# Install Go dependencies
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
 # Pull down any dependencies and build the filewatcher daemon go app
-WORKDIR /go/src/github.ibm.com/builder/Filewatcherd-Go/
+WORKDIR /go/src/github.com/eclipse/codewind-filewatchers/Filewatcherd-Go/
 COPY ./codewind-filewatchers/Filewatcherd-Go/src/codewind/ .
-RUN dep init
-RUN dep ensure -v
 RUN GOPATH= CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o filewatcherd .
 
 # Build base image for the nginx based sidecar container
@@ -28,7 +23,7 @@ FROM nginx:stable-alpine
 RUN apk --no-cache add curl openssl
 
 WORKDIR /usr/local/bin
-COPY --from=builder /go/src/github.ibm.com/builder/Filewatcherd-Go/filewatcherd .
+COPY --from=builder /go/src/github.com/eclipse/codewind-filewatchers/Filewatcherd-Go/filewatcherd .
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./site.conf /etc/nginx/conf.d-default/default.conf


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind-che-plugin/issues/17

Looks like a couple internal IBM links were missed when we open sourced, this PR removes them. This PR also removes `dep` as a dependency on filewatcher-Go, as it's no longer required