### PR TITLE
Version the Codewind Che Plugins

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -85,7 +85,7 @@ spec:
           secretName: REGISTRY_SECRET_PLACEHOLDER
       containers:
       - name: codewind-pfe
-        image: sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe-amd64:latest
+        image: ibmcom/codewind-pfe-amd64:0.2
         imagePullPolicy: "Always"
         securityContext:
           privileged: true

--- a/devfiles/devfile.yaml
+++ b/devfiles/devfile.yaml
@@ -43,8 +43,8 @@ components:
     id: eclipse/che-machine-exec-plugin/0.0.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.0.1/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.2.0/meta.yaml
 

--- a/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
@@ -1,0 +1,33 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+id: codewind-sidecar
+apiVersion: v2
+version: 0.2.0
+type: Che Plugin
+name: CodewindPlugin
+title: CodewindPlugin
+description: Enables iterative development and deployment in Che
+icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+publisher: IBM
+repository: https://github.com/eclipse/codewind-che-plugin
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-06-26"
+spec:
+  containers:
+  - name: codewind-che-sidecar
+    image: ibmcom/codewind-che-sidecar:0.2
+    volumes:
+      - mountPath: "/projects"
+        name: projects
+    ports:
+      - exposedPort: 9090

--- a/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/0.2.0/meta.yaml
@@ -16,7 +16,7 @@ type: Che Plugin
 name: CodewindPlugin
 title: CodewindPlugin
 description: Enables iterative development and deployment in Che
-icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
 publisher: IBM
 repository: https://github.com/eclipse/codewind-che-plugin
 category: Other

--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -1,0 +1,33 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+id: codewind-sidecar
+apiVersion: v2
+version: latest
+type: Che Plugin
+name: CodewindPlugin
+title: CodewindPlugin
+description: Enables iterative development and deployment in Che
+icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+publisher: IBM
+repository: https://github.com/eclipse/codewind-che-plugin
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-06-26"
+spec:
+  containers:
+  - name: codewind-che-sidecar
+    image: ibmcom/codewind-che-sidecar:latest
+    volumes:
+      - mountPath: "/projects"
+        name: projects
+    ports:
+      - exposedPort: 9090

--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -16,7 +16,7 @@ type: Che Plugin
 name: CodewindPlugin
 title: CodewindPlugin
 description: Enables iterative development and deployment in Che
-icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
 publisher: IBM
 repository: https://github.com/eclipse/codewind-che-plugin
 category: Other

--- a/plugins/codewind/codewind-theia/0.2.0/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.2.0/meta.yaml
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+apiVersion: v2
+publisher: IBM
+name: codewind-plugin
+version: 0.
+type: VS Code extension
+displayName: Codewind VS Code Extension
+title: Codewind Extension for VS Code
+description: Codewind Extension for Theia
+icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+repository: http://github.com/eclipse/codewind-vscode/
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-06-26"
+spec:
+  extensions:
+    - http://download.eclipse.org/codewind/milestone/0.2.0/codewind-theia-0.2.0.vsix

--- a/plugins/codewind/codewind-theia/0.2.0/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.2.0/meta.yaml
@@ -17,7 +17,7 @@ type: VS Code extension
 displayName: Codewind VS Code Extension
 title: Codewind Extension for VS Code
 description: Codewind Extension for Theia
-icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
 repository: http://github.com/eclipse/codewind-vscode/
 category: Other
 firstPublicationDate: "2019-05-30"

--- a/plugins/codewind/codewind-theia/0.2.0/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.2.0/meta.yaml
@@ -12,7 +12,7 @@
 apiVersion: v2
 publisher: IBM
 name: codewind-plugin
-version: 0.
+version: 0.2.0
 type: VS Code extension
 displayName: Codewind VS Code Extension
 title: Codewind Extension for VS Code

--- a/plugins/codewind/codewind-theia/latest/meta.yaml
+++ b/plugins/codewind/codewind-theia/latest/meta.yaml
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+apiVersion: v2
+publisher: IBM
+name: codewind-plugin
+version: latest
+type: VS Code extension
+displayName: Codewind VS Code Extension
+title: Codewind Extension for VS Code
+description: Codewind Extension for Theia
+icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+repository: http://github.com/eclipse/codewind-vscode/
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-06-26"
+spec:
+  extensions:
+    - http://download.eclipse.org/codewind/milestone/0.2.0/codewind-theia-0.2.0.vsix

--- a/plugins/codewind/codewind-theia/latest/meta.yaml
+++ b/plugins/codewind/codewind-theia/latest/meta.yaml
@@ -17,7 +17,7 @@ type: VS Code extension
 displayName: Codewind VS Code Extension
 title: Codewind Extension for VS Code
 description: Codewind Extension for Theia
-icon: https://raw.githubusercontent.com/IBM/charts/master/logo/microclimate-logo.png
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
 repository: http://github.com/eclipse/codewind-vscode/
 category: Other
 firstPublicationDate: "2019-05-30"


### PR DESCRIPTION
This PR adds proper versioning to the Codewind Che plugins:
- Creates two versions of the Che plugins: `latest` and `0.2.0`
    - `latest` points to the latest sidecar image, `0.2.0` points to the `0.2` tag of the sidecar image
- Updates the reference devfile to point to `0.2.0` version of the plugins
- Updates the Codewind deployment yaml to point to `ibmcom/codewind-pfe-amd64:0.2`, rather than Artifactory