### PR TITLE
Update devfiles to use Che-Theia RC3

### DIFF
--- a/devfiles/0.2.0/devfile.yaml
+++ b/devfiles/0.2.0/devfile.yaml
@@ -37,7 +37,7 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/next
+    id: eclipse/che-theia/7.0.0-rc-3.0
   - alias: exec-plugin
     type: chePlugin
     id: eclipse/che-machine-exec-plugin/0.0.1

--- a/devfiles/devfile.yaml
+++ b/devfiles/devfile.yaml
@@ -37,7 +37,7 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/next
+    id: eclipse/che-theia/7.0.0-rc-3.0
   - alias: exec-plugin
     type: chePlugin
     id: eclipse/che-machine-exec-plugin/0.0.1

--- a/devfiles/latest/devfile.yaml
+++ b/devfiles/latest/devfile.yaml
@@ -37,7 +37,7 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/next
+    id: eclipse/che-theia/7.0.0-rc-3.0
   - alias: exec-plugin
     type: chePlugin
     id: eclipse/che-machine-exec-plugin/0.0.1


### PR DESCRIPTION
Updates the Codewind Che devfiles to point to Theia RC3 instead of Theia nightly/next.

Tested:
- Project Creation:
   - Bind from existing project
   - Create new project from template
- Overview
   - Overview page
   - Open app via overview page
   - Disable app via overview page
   - Delete app via overview page
   - Editing the settings will open the project's settings file
- Logs
   - Show logs
   - Hide logs
- Updates:
   - Project code updates can be made, and the status for the project in Theia updates accordingly
   - Opening the app via Theia shows the updated app
   - Toggling auto-build
   - Manual build
- Miscellaneous
   - Codewind command palette works (along with the commands there)
   - Docker registry command works