### PR TITLE
Point back to Codewind PFE master for the Che plugin

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -85,7 +85,7 @@ spec:
           secretName: REGISTRY_SECRET_PLACEHOLDER
       containers:
       - name: codewind-pfe
-        image: ibmcom/codewind-pfe-amd64:0.2
+        image: sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe-amd64:latest
         imagePullPolicy: "Always"
         securityContext:
           privileged: true


### PR DESCRIPTION
Updates the Codewind PFE deployment yaml in the Codewind-che sidecar to point to the latest images of Codewind PFE, rather than our tagged `ibmcom/codewind-pfe-amd64:0.2` image