### PR TITLE
Use `eclipse` instead of `ibmcom` for the sidecar

### DIFF
--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -25,7 +25,7 @@ latestUpdateDate: "2019-06-26"
 spec:
   containers:
   - name: codewind-che-sidecar
-    image: ibmcom/codewind-che-sidecar:latest
+    image: eclipse/codewind-che-sidecar:latest
     volumes:
       - mountPath: "/projects"
         name: projects


### PR DESCRIPTION
Sets `eclipse` to be the image repository location for the Codewind Che sidecar plugin