### PR TITLE
Update Codewind role for ingresses/routes

### DIFF
--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -58,7 +58,7 @@ rules:
 
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
-  verbs: ["get", "patch"]
+  verbs: ["get", "list", "create", "delete", "watch"]
 
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
@@ -91,3 +91,7 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
+
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get", "list", "create", "delete", "watch"]


### PR DESCRIPTION
Required for https://github.com/eclipse/codewind-che-plugin/pull/27 to properly function on OpenShift. Adds necessary roles to create routes, and updates the current ingress roles to use what OpenShift requires.