### PR TITLE
Add mattermost badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Use the Eclipse Codewind sidecar plug-in for Eclipse Che to enable Theia to communicate with the Codewind server container.
 
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
+[![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=145dbf)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
 
 ## What is the Eclipse Codewind sidecar container?
 The Codewind sidecar container includes the following responsibilities:


### PR DESCRIPTION
Codewind's official method of communication is via mattermost, so adding a badge linking to the Mattermost channel on the readme.