### PR TITLE
Link to official Eclipse Codewind docker image

### DIFF
--- a/.github/ISSUE_TEMPLATE/where-to-report-issues.md
+++ b/.github/ISSUE_TEMPLATE/where-to-report-issues.md
@@ -1,0 +1,16 @@
+---
+name: "⚠️ Where to report issues?"
+about: File issues in the main Eclipse Codewind repository at https://github.com/eclipse/codewind/issues
+title: Issues need to be filed in the main Eclipse Codewind repository
+labels: ''
+assignees: ''
+
+---
+
+## Where to report issues?
+
+This repository is not used for issue tracking of the Codewind plugin for Eclipse Che
+
+🚨 Please don't submit new issues here. 🚨
+
+All issues for the Eclipse Codewind plugin for Che are managed at [https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To build the sidecar image, run `./build.sh`.
 For deployment instructions, see the README.md file at [eclipse/codewind-che-plugin](https://github.com/eclipse/codewind-che-plugin/tree/master/scripts).
 
 ## Contributing
+We use the main Codewind git repo (https://github.com/eclipse/codewind) for issue tracking.
+
 Submit issues and contributions:
-1. [Submitting issues](https://github.com/eclipse/codewind-che-plugin/issues)
+1. [Submitting issues](https://github.com/eclipse/codewind/issues)
 2. [Contributing](CONTRIBUTING.md)

--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -85,7 +85,7 @@ spec:
           optional: true
       containers:
       - name: codewind-pfe
-        image: sys-mcs-docker-local.artifactory.swg-devops.com/codewind-pfe-amd64:latest
+        image: eclipse/codewind-pfe-amd64:latest
         imagePullPolicy: "Always"
         securityContext:
           privileged: true


### PR DESCRIPTION
Updates the Codewind template yaml to point to the official, latest Docker image for Eclipse Codewind (`eclipse/codewind-pfe-amd64:latest`). Also adds an issue template to this repo telling users to open issues in https://github.com/eclipse/codewind instead

Link to Codewind issue: https://github.com/eclipse/codewind/issues/42

Signed-off-by: John Collier <John.J.Collier@ibm.com>