### PR TITLE
Always point to latest Theia plugin file

### DIFF
--- a/plugins/codewind/codewind-theia/latest/meta.yaml
+++ b/plugins/codewind/codewind-theia/latest/meta.yaml
@@ -10,7 +10,7 @@
 ################################################################################
 
 apiVersion: v2
-publisher: IBM
+publisher: eclipse
 name: codewind-plugin
 version: latest
 type: VS Code extension
@@ -24,4 +24,4 @@ firstPublicationDate: "2019-05-30"
 latestUpdateDate: "2019-06-26"
 spec:
   extensions:
-    - http://download.eclipse.org/codewind/milestone/0.2.0/codewind-theia-0.2.0.vsix
+    - http://download.eclipse.org/codewind/codewind-vscode/master/latest/codewind-theia.vsix

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -58,7 +58,7 @@ EOF
 mkdir -p $BASE_DIR/publish/codewind-theia/latest
 cat <<EOF > publish/codewind-theia/latest/meta.yaml
 apiVersion: v2
-publisher: Eclipse
+publisher: eclipse
 name: codewind-plugin
 version: latest
 type: VS Code extension
@@ -72,7 +72,7 @@ firstPublicationDate: "2019-05-30"
 latestUpdateDate: "$(date '+%Y-%m-%d')"
 spec:
   extensions:
-    - http://download.eclipse.org/codewind/milestone/0.2.0/codewind-theia-0.2.0.vsix
+    - http://download.eclipse.org/codewind/codewind-vscode/master/latest/codewind-theia.vsix
 
 EOF
 


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
This PR updates the `latest` codewind-theia Che plugin so that it's always downloading the latest version of the Codewind theia extension.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A
