### PR TITLE
change RoleBinding to ClusterRoleBinding

### DIFF
--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -85,7 +85,7 @@ spec:
           optional: true
       containers:
       - name: codewind-pfe
-        image: tobespc/codewind-pfe-amd64:latest
+        image: eclipse/codewind-pfe-amd64:latest
         imagePullPolicy: "Always"
         securityContext:
           privileged: true

--- a/codewind-che-sidecar/scripts/kube/codewind_template.yaml
+++ b/codewind-che-sidecar/scripts/kube/codewind_template.yaml
@@ -85,7 +85,7 @@ spec:
           optional: true
       containers:
       - name: codewind-pfe
-        image: eclipse/codewind-pfe-amd64:latest
+        image: tobespc/codewind-pfe-amd64:latest
         imagePullPolicy: "Always"
         securityContext:
           privileged: true
@@ -98,6 +98,8 @@ spec:
         - name: registry-secret
           mountPath: "/tmp/secret"
         env:
+          - name: TEKTON_PIPELINE
+            value: tekton-pipelines
           - name: IN_K8
             value: "true"
           - name: PORTAL_HTTPS

--- a/setup/install_che/codewind-rolebinding.yaml
+++ b/setup/install_che/codewind-rolebinding.yaml
@@ -8,12 +8,13 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: codewind-rolebinding
 subjects:
 - kind: ServiceAccount
+  namespace: eclipse-che
   name: che-workspace
 roleRef:
   kind: ClusterRole

--- a/setup/install_che/codewind-tektonbinding.yaml
+++ b/setup/install_che/codewind-tektonbinding.yaml
@@ -8,14 +8,15 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: codewind-rolebinding
+  name: codewind-tektonbinding
 subjects:
 - kind: ServiceAccount
+  namespace: eclipse-che
   name: che-workspace
 roleRef:
   kind: ClusterRole
-  name: eclipse-codewind
+  name: codewind-tekton
   apiGroup: rbac.authorization.k8s.io

--- a/setup/install_che/codewind-tektonrole.yaml
+++ b/setup/install_che/codewind-tektonrole.yaml
@@ -1,0 +1,20 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: codewind-tekton
+rules:
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get"]
+

--- a/setup/install_che/install.sh
+++ b/setup/install_che/install.sh
@@ -44,6 +44,7 @@ fi
 
 # Create the cluster role needed for Codewind
 kubectl apply -f ${BASE_DIR}/codewind-clusterrole.yaml
+kubectl apply -f ${BASE_DIR}/codewind-tektonrole.yaml
 
 if [[ "$INSTALL_MODE" == "operator" ]]; then
     # Install Che via the operator
@@ -78,6 +79,7 @@ elif [[ "$INSTALL_MODE" == "os" ]]; then
 
     # Create the role binding
     kubectl apply -f ${BASE_DIR}/codewind-rolebinding.yaml -n eclipse-che
+    kubectl apply -f ${BASE_DIR}/codewind-tektonbinding.yaml -n eclipse-che
 else
     # Deploy using the Helm chart
     if [[ -z "$INGRESS_DOMAIN" ]]; then
@@ -102,4 +104,5 @@ else
         --set che.workspace.pluginRegistryUrl="https://che-plugin-registry.openshift.io/v3" ./
     
     kubectl apply -f ${BASE_DIR}/codewind-rolebinding.yaml -n $CHE_NAMESPACE
+    kubectl apply -f ${BASE_DIR}/codewind-tektonbinding.yaml -n $CHE_NAMESPACE
 fi


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>


I've made change to the RoleBinding to make it a ClusterRoleBinding.  This is so that the serviceaccount associated with this role can access ingress in other namespaces.  I need to access ingress to be able to reference the tekton pipeline ingress endpoint

