### PR TITLE
Add image tag to publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,25 +13,33 @@
 
 # Pushes the Nginx sidecar image up to the specified registry
 
-set -eu
+set -e
 
-if [ "$#" -ne 1 ]; then
-    echo "usage: $0 <registry-to-push-sidecar-to>"
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <registry-to-push-sidecar-to> <image-tag>"
     exit 1
 fi
 
 REGISTRY=$1
+
+# Set the image tag
+if [ -z "$2" ]; then
+    TAG=latest
+else
+    TAG=$2
+fi
+
 BASE_DIR=$(dirname pwd)
 
-docker tag codewind-che-sidecar $REGISTRY/codewind-che-sidecar
-docker push $REGISTRY/codewind-che-sidecar
+docker tag codewind-che-sidecar $REGISTRY/codewind-che-sidecar:$TAG
+docker push $REGISTRY/codewind-che-sidecar:$TAG
 
 # Create the meta.yaml for the Sidecar container
-mkdir -p $BASE_DIR/publish/codewind-sidecar/latest
-cat <<EOF > publish/codewind-sidecar/latest/meta.yaml
+mkdir -p $BASE_DIR/publish/codewind-sidecar/$TAG
+cat <<EOF > publish/codewind-sidecar/$TAG/meta.yaml
 id: codewind-sidecar
 apiVersion: v2
-version: latest
+version: $TAG
 type: Che Plugin
 name: CodewindPlugin
 title: CodewindPlugin
@@ -45,7 +53,7 @@ latestUpdateDate: "$(date '+%Y-%m-%d')"
 spec:
   containers:
   - name: codewind-che-sidecar
-    image: $REGISTRY/codewind-che-sidecar:latest
+    image: $REGISTRY/codewind-che-sidecar:$TAG
     volumes:
       - mountPath: "/projects"
         name: projects
@@ -55,12 +63,12 @@ spec:
 EOF
 
 # Create the meta.yaml for the Theia extension
-mkdir -p $BASE_DIR/publish/codewind-theia/latest
-cat <<EOF > publish/codewind-theia/latest/meta.yaml
+mkdir -p $BASE_DIR/publish/codewind-theia/$TAG
+cat <<EOF > publish/codewind-theia/$TAG/meta.yaml
 apiVersion: v2
 publisher: eclipse
 name: codewind-plugin
-version: latest
+version: $TAG
 type: VS Code extension
 displayName: Codewind VS Code Extension
 title: Codewind Extension for VS Code


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

### What does this PR do?
Updates the publish.sh script to specify a tag/version for the Codewind Che plugin, set to `latest` by default. It'll tag the image with the specified version, and also set the version in the meta.yaml's to be what was specified.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A