### PR TITLE
Improve the development experience for the plugin

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,10 @@
 ## Building & Using the Codewind Plugin on Che
 
+### Set the Codewind container image
+
+If deploying a custom image of Codewind from https://github.com/eclipse/codewind, make sure to set https://github.com/eclipse/codewind-che-plugin/blob/master/codewind-che-sidecar/scripts/kube/codewind_template.yaml#L88 to point to your tagged and pushed `codewind-pfe-amd64` docker image.
+ - Otherwise, leave it as `eclipse/codewind-pfe-amd64:latest`
+
 ### Build the Codewind plugin
 
 Run the script build.sh to build the Codewind Che sidecar.
@@ -11,7 +16,8 @@ Run the script build.sh to build the Codewind Che sidecar.
 
 2. Upload the meta.yamls somewhere publicly accessible, such as a GitHub repository.
 
-3. Finally, to create a Che Codewind workspace, write a dev file and host it publicly, such as on Github. Make sure to set the URLs for `codewind-sidecar` and `codewind-theia` accordingly. If hosting the plugin meta.yamls on GitHub, make sure you use the raw Github link (such as https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/latest/meta.yaml)
+3. Finally, to create a Che Codewind workspace, write a devfile and host it publicly, such as on Github. Make sure to set the URLs for `codewind-sidecar` and `codewind-theia` accordingly. If hosting the plugin meta.yamls on GitHub, make sure you use the raw Github link
+    - Such as https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/latest/meta.yaml
 
 ```
 apiVersion: 1.0.0
@@ -34,8 +40,8 @@ components:
     id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/latest/meta.yaml
 ```
   
-  Then create the workspace in Che by accessing http://$CHE_DOMAIN/f?url=${DEVFILE_LINK} in your browser, where `${DEVFILE_LINK}` is the direct link to the devfile you created. If the devfile is hosted on Github, make sure you use the raw Github link (such as https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml) Che will then create a workspace from that devfile.
-  - An example of such a link is: http://che-eclipse-che.1.2.3.4.nip.io/f?url=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml
+  Then create the workspace in Che by accessing `http://$CHE_DOMAIN/f?url=${DEVFILE_LINK}` in your browser, where `${DEVFILE_LINK}` is the direct link to the devfile you created. Che will then create a workspace from that devfile.
+  - An example of such a link is: http://che-eclipse-che.1.2.3.4.nip.io/f?url=https://github.com/eclipse/codewind-che-plugin/blob/master/devfiles/latest/devfile.yaml
 
 
       

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build the sidecar image, run `./build.sh`.
 
 ### Deploying
 
-For instructions on deploying custom builds of the Codewind Che plugin, see the README.md file at [eclipse/codewind-che-plugin/scripts](https://github.com/eclipse/codewind-che-plugin/tree/master/scripts).
+For instructions on deploying custom builds of the Codewind Che plugin, consult DEVELOPING.md
 
 ## Contributing
 We use the main Codewind git repo (https://github.com/eclipse/codewind) for issue tracking.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -29,7 +29,8 @@ else
     TAG=$2
 fi
 
-BASE_DIR=$(dirname pwd)
+SCRIPTS_DIR="$(dirname $0)"
+BASE_DIR="$(dirname $SCRIPTS_DIR)"
 
 docker tag codewind-che-sidecar $REGISTRY/codewind-che-sidecar:$TAG
 docker push $REGISTRY/codewind-che-sidecar:$TAG


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
- Moves the development doc for codewind-che-plugin into `DEVELOPING.md` in the root of the repository, making it easier for users to find.
    - Also adds a section to doc on specifying custom images of codewind-pfe-amd64
    - Removes a section saying a raw github link is required when creating a factory from a devfile hosted on Github. This is **not** required any more.
- Updates the publish.sh script so that it can be run anywhere

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A