### PR TITLE
Fix DEVELOPING.md, tell users to use the raw github link

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -41,7 +41,8 @@ components:
 ```
   
   Then create the workspace in Che by accessing `http://$CHE_DOMAIN/f?url=${DEVFILE_LINK}` in your browser, where `${DEVFILE_LINK}` is the direct link to the devfile you created. Che will then create a workspace from that devfile.
-  - An example of such a link is: http://che-eclipse-che.1.2.3.4.nip.io/f?url=https://github.com/eclipse/codewind-che-plugin/blob/master/devfiles/latest/devfile.yaml
+  - An example of such a link is: http://che-eclipse-che.1.2.3.4.nip.io/f?url=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml
+  - If hosting the Devfile on Github, make sure to use its raw link (such as https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml)
 
 
       


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates DEVELOPING.md to tell users to use the raw github link for devfiles and plugins.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A