### PR TITLE
Update readme and contributing docs to link to developing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@ Contributions must follow the Eclipse organization specifications. See the [Git 
 If you identified a problem or have a feature request, please check the [issues in the Codewind repository https://github.com/eclipse/codewind/issues](https://github.com/eclipse/codewind/issues) to see if your issue has already been raised. If you do not see your issue, open a new one.
 	
 Please provide context so that we can understand the problem and try to recreate the issue.
+
+## Bulding and Deploying Codewind Che plugin
+
+Please consult [DEVELOPING.md](DEVELOPING.md) for instructions on building and deploying the Codewind Che plugin

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build the sidecar image, run `./build.sh`.
 
 ### Deploying
 
-For instructions on deploying custom builds of the Codewind Che plugin, consult DEVELOPING.md
+For instructions on deploying custom builds of the Codewind Che plugin, consult [DEVELOPING.md](DEVELOPING.md)
 
 ## Contributing
 We use the main Codewind git repo (https://github.com/eclipse/codewind) for issue tracking.


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the README.md and CONTRIBUTING.md docs to link to the new DEVELOPING.md doc that we have

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A