### PR TITLE
Add namespace field back to the tekton binding

### DIFF
--- a/setup/install_che/codewind-tektonbinding.yaml
+++ b/setup/install_che/codewind-tektonbinding.yaml
@@ -14,6 +14,7 @@ metadata:
   name: codewind-tektonbinding
 subjects:
 - kind: ServiceAccount
+  namespace: eclipse-che
   name: che-workspace
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Adds the namespace field back to the codewind-tektonbinding file so that the clusterrolebinding can be properly created

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A