### PR TITLE
Skip publishing docker images from non-release branch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 
                         # Publish docker images with a filter for branch name
                         # Acceptable branch names: master, start with '<number>.<number>'
-                        if [[ $GIT_BRANCH == "master" ]] || [[ $GIT_BRANCH =~ ^([0-9]+.[0-9]+) ]]; then
+                        if [[ $GIT_BRANCH == "master" ]] || [[ $GIT_BRANCH =~ ^([0-9]+\.[0-9]+) ]]; then
                             echo "Publishing docker images for Eclipse Codewind Che Sidecar..."
                             echo "publish.sh eclipse $TAG"
                             ./scripts/publish.sh eclipse $TAG

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,10 @@ pipeline {
         timestamps()
         skipStagesAfterUnstable()
     }
+    
+    triggers {	
+      issueCommentTrigger('trigger_build')	
+    }
 
     stages {
         stage('Build Docker image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,6 @@ pipeline {
     agent {
         label "docker-build"
     }
-
-    triggers {
-      issueCommentTrigger('trigger_build')
-    }
     
     options {
         timestamps()
@@ -25,6 +21,15 @@ pipeline {
         }
         
         stage('Publish Docker image') {
+
+            // This when clause disables PR build uploads; you may comment this out if you want your build uploaded.
+            when {
+                beforeAgent true
+                not {
+                    changeRequest()
+                }
+            }
+
             steps {
                 withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
                     sh '''#!/usr/bin/env bash
@@ -34,12 +39,14 @@ pipeline {
                             TAG=$GIT_BRANCH
                         fi        
 
-                        if [ -z $CHANGE_ID ]; then
+                        # Publish docker images with a filter for branch name
+                        # Acceptable branch names: master, start with '<number>.<number>'
+                        if [[ $GIT_BRANCH == "master" ]] || [[ $GIT_BRANCH =~ ^([0-9]+.[0-9]+) ]]; then
                             echo "Publishing docker images for Eclipse Codewind Che Sidecar..."
                             echo "publish.sh eclipse $TAG"
                             ./scripts/publish.sh eclipse $TAG
                         else
-                            echo "Skip publishing docker images for the PR build"
+                            echo "Skip publishing docker images for $GIT_BRANCH branch"
                         fi
                     '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,15 +5,15 @@ pipeline {
         label "docker-build"
     }
     
+    triggers {	
+      issueCommentTrigger('trigger_build')	
+    }
+
     options {
         timestamps()
         skipStagesAfterUnstable()
     }
     
-    triggers {	
-      issueCommentTrigger('trigger_build')	
-    }
-
     stages {
         stage('Build Docker image') {
             steps {


### PR DESCRIPTION
https://github.com/eclipse/codewind/issues/143

This allows publishing docker images only from 'master' or release branches so that it allows for creating a collaboration branch with no impact on dockerhub images.