### PR TITLE
Update development docs for deploy-pfe and clean up devfiles/plugins

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,8 +2,8 @@
 
 ### Set the Codewind container image
 
-If deploying a custom image of Codewind from https://github.com/eclipse/codewind, make sure to set https://github.com/eclipse/codewind-che-plugin/blob/master/codewind-che-sidecar/scripts/kube/codewind_template.yaml#L88 to point to your tagged and pushed `codewind-pfe-amd64` docker image.
- - Otherwise, leave it as `eclipse/codewind-pfe-amd64:latest`
+If deploying a custom image of Codewind from https://github.com/eclipse/codewind, make sure to update https://github.com/eclipse/codewind-che-plugin/blob/master/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go to point to your tagged and pushed `codewind-pfe-amd64` and `codewind-performance-amd64` docker images.
+ - Otherwise, leave them as `eclipse/codewind-pfe-amd64` and `eclipse/codewind-performance-amd64`
 
 ### Build the Codewind plugin
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Codewind Che Plug-in
-Use the Eclipse Codewind sidecar plug-in for Eclipse Che to enable Theia to communicate with the Codewind server container.
+Create and develop cloud-native, containerized web applications with Codewind on Eclipse Che
 
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
 [![Build Status](https://ci.eclipse.org/codewind/buildStatus/icon?job=Codewind%2Fcodewind-che-plugin%2Fmaster)](https://ci.eclipse.org/codewind/job/Codewind/job/codewind-che-plugin/job/master/)
 [![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=145dbf)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
 
+## Installing Codewind on Eclipse Che
+
+To install Codewind on Eclipse Che, please consult [Installing and Using Codewind on Kubernetes](https://www.eclipse.org/codewind/installoncloud.html)
+
 ## What is the Eclipse Codewind sidecar container?
 The Codewind sidecar container includes the following responsibilities:
-- The sidecar deploys the Codewind server container.
-    - The sidecar renders the deployment and service templates and applies them with the `kubectl apply` command.
-    - When the workspace is shut down or deleted, the sidecar tears down Codewind and any deployed applications.
+- The sidecar deploys the Codewind server and Performance Dashboard containers.
+    - The Golang-based [deploy-pfe](https://github.com/eclipse/codewind-che-plugin/tree/master/codewind-che-sidecar/deploy-pfe) utility handles this
+    - When the workspace is shut down or deleted, the Codewind containers and projects are automatically torn down too.
 - The sidecar sets up a reverse proxy for the Theia extension.
     - Nginx is used for the proxy because it can handle both HTTP requests and socket.io.
     - The Theia plug-in communicates with the reverse proxy, which then forwards requests to Codewind. This chain of communication avoids the addition of code in the Theia plug-in to discover and manage the connection to Codewind.
 - The sidecar runs the `filewatcherd` daemon to track user code changes.
     - The `filewatcherd` daemon watches for changes in each user's project and communicates with Codewind, letting it know to start a build if required.
     - For more information on `filewatcherd`, see [eclipse/codewind-filewatchers](https://github.com/eclipse/codewind-filewatchers).
-
-## Installing Codewind on Eclipse Che
-
-To install Codewind on Eclipse Che, please consult [Installing and Using Codewind on Kubernetes](https://www.eclipse.org/codewind/installoncloud.html)
 
 ## Developing
 

--- a/devfiles/latest/devfile.yaml
+++ b/devfiles/latest/devfile.yaml
@@ -21,15 +21,15 @@ projects:
   - name: springproj
     source:
       type: git
-      location: 'https://github.com/maysunfaisal/maysunspring1.git'
+      location: 'https://github.com/microclimate-dev2ops/springJavaTemplate'
   - name: swiftproj
     source:
       type: git
-      location: 'https://github.com/maysunfaisal/maysunswi.git'
+      location: 'https://github.com/microclimate-dev2ops/swiftTemplate'
   - name: microproj
     source:
       type: git
-      location: 'https://github.com/maysunfaisal/hellomicro.git'
+      location: 'https://github.com/microclimate-dev2ops/javaMicroProfileTemplate'
   - name: nodeTemplate
     source:
       type: git
@@ -37,7 +37,7 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.0.0-rc-3.0
+    id: eclipse/che-theia/7.0.0-rc-4.0
   - alias: exec-plugin
     type: chePlugin
     id: eclipse/che-machine-exec-plugin/0.0.1

--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -17,7 +17,7 @@ name: CodewindPlugin
 title: CodewindPlugin
 description: Enables iterative development and deployment in Che
 icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
-publisher: IBM
+publisher: eclipse
 repository: https://github.com/eclipse/codewind-che-plugin
 category: Other
 firstPublicationDate: "2019-05-30"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -46,7 +46,7 @@ name: CodewindPlugin
 title: CodewindPlugin
 description: Enables iterative development and deployment in Che
 icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
-publisher: Eclipse
+publisher: eclipse
 repository: https://github.com/eclipse/codewind-che-plugin
 category: Other
 firstPublicationDate: "2019-05-30"
@@ -60,7 +60,6 @@ spec:
         name: projects
     ports:
       - exposedPort: 9090
-
 EOF
 
 # Create the meta.yaml for the Theia extension
@@ -82,7 +81,6 @@ latestUpdateDate: "$(date '+%Y-%m-%d')"
 spec:
   extensions:
     - http://download.eclipse.org/codewind/codewind-vscode/master/latest/codewind-theia.vsix
-
 EOF
 
 echo "Published the codewind-sidecar and codewind-theia meta.yamls under $BASE_DIR/publish"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
* Updates our README.md and DEVELOPING.md to refer to the `deploy-pfe` utility that's now used in the repo. 
* Cleans up the devfiles and plugin meta.yamls:
    * Removes Maysun's fork of the project templates and uses the official repo instead
    * Makes `eclipse` the publisher of the Codewind Che sidecar, rather than `IBM` (Just as Red Hat does for its Che plugins). This was already done for the Theia plugin previously.
    * Bumps the Theia version up to 7.0.0-RC4, as per @tetchel's request.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
- Verify that README.md and DEVELOPING.md refer to the `deploy-pfe` utility
- Verify the devfile here: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/3dff9fa5e1ab89ac9c81308985cc000dbd78d2ad/devfiles/latest/devfile.yaml can be used to create a Codewind workspace