### PR TITLE
Add patch permision for codewind deployments

### DIFF
--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -58,7 +58,7 @@ rules:
 
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
-  verbs: ["watch", "get", "list", "create", "update", "delete"]
+  verbs: ["watch", "get", "list", "create", "update", "delete", "patch"]
 
 - apiGroups: ["extensions", "apps"]
   resources: ["replicasets", "replicasets/finalizers"]


### PR DESCRIPTION
Signed-off-by: ssh24 <sakib@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Add `patch` permission for users to patch their codewind deployments.

### How can this PR be tested?
Patch the service port deployment and codewind should pick it up.