### PR TITLE
Improve Che API URL parsing, add support for HTTPS

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/main.go
+++ b/codewind-che-sidecar/deploy-pfe/main.go
@@ -44,6 +44,7 @@ func main() {
 	cheWorkspaceID := os.Getenv("CHE_WORKSPACE_ID")
 	if cheWorkspaceID == "" {
 		log.Errorln("Che Workspace ID not set and unable to deploy PFE, exiting...")
+		os.Exit(1)
 	}
 
 	// If deploy-pfe was called with the `get-service` arg, retrieve the codewind service name if it exists, and exit
@@ -59,7 +60,11 @@ func main() {
 	log.Infof("PVC: %s\n", workspacePVC)
 
 	// Get the ingress domain used for Che (and Che workspaces)
-	cheIngress := che.GetCheIngress()
+	cheIngress, err := che.GetCheIngress(os.Getenv("CHE_API"))
+	if err != nil {
+		log.Errorf("Unable to determine Che ingress domain: %v\n", err)
+		os.Exit(1)
+	}
 	log.Infof("Ingress: %s\n", cheIngress)
 
 	// Get the Che workspace service account to use with Codewind

--- a/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
@@ -124,7 +124,7 @@ func GetCheIngress(cheAPI string) (string, error) {
 	}
 
 	// Return the hostname of the Che API URL. This will have the http/https and path stripped out
-	return cheURL.Hostname(), nil
+	return parsedURL, nil
 
 }
 

--- a/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
@@ -110,7 +110,7 @@ func GetOwnerReferences(clientset *kubernetes.Clientset, namespace string, cheWo
 func GetCheIngress(cheAPI string) (string, error) {
 	// Log an error and return if a blank string was passed in
 	if cheAPI == "" {
-		return "", fmt.Errorf("Che Workspace ID is not set")
+		return "", fmt.Errorf("Che API URL was not set")
 	}
 
 	cheURL, err := url.Parse(cheAPI)

--- a/codewind-che-sidecar/deploy-pfe/pkg/che/che_test.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/che/che_test.go
@@ -1,0 +1,69 @@
+package che
+
+import (
+	"fmt"
+	"testing"
+)
+
+var CheIngress = "che-eclipse-che.9.1.2.3.nip.io"
+
+func TestParseValidCheAPI(t *testing.T) {
+	tests := []struct {
+		name   string
+		cheAPI string
+	}{
+		{
+			name:   fmt.Sprintf("Parse valid Che API URL, with HTTP"),
+			cheAPI: "http://" + CheIngress + "/api",
+		},
+		{
+			name:   fmt.Sprintf("Parse valid Che API URL, with HTTPS"),
+			cheAPI: "https://" + CheIngress + "/api",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedIngress, err := GetCheIngress(tt.cheAPI)
+
+			// Test should fail if we're unable to parse a valid Che API URL
+			if err != nil {
+				t.Error(err)
+			}
+
+			// Test should fail if the parsed ingress domain doesn't match our expected ingress domain
+			if parsedIngress != CheIngress {
+				t.Errorf("Parsed ingress doesn't match expected ingress. Have: %v, expected %v", parsedIngress, CheIngress)
+			}
+		})
+	}
+}
+
+func TestParseInvalidCheAPI(t *testing.T) {
+	tests := []struct {
+		name   string
+		cheAPI string
+	}{
+		{
+			name:   fmt.Sprintf("Invalid CHE API URL, no path"),
+			cheAPI: "://" + CheIngress,
+		},
+		{
+			name:   fmt.Sprintf("Invalid CHE API URL, with path"),
+			cheAPI: "://" + CheIngress + "/api",
+		},
+		{
+			name:   fmt.Sprintf("Invalid Che API URL, no protocol"),
+			cheAPI: CheIngress + "/api",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedIngress, err := GetCheIngress(tt.cheAPI)
+
+			// GetCheIngress should return an error here, so the test should fail if it doesn't
+			if err == nil || parsedIngress != "" {
+				t.Errorf("Che API URL parsing didn't fail as expected. Parsed Che Ingress: %v\n", parsedIngress)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
- Allows Codewind to be deployed on Che installs that use HTTPS.
- Cleans up the GetCheIngress function to use the Golang `net/url` library instead
- Adds some unit tests for the GetCheIngress function

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/219

### Does this PR require updates to the docs?
N/A

### How can this PR be tested?
Deploy Che with HTTPS enabled (such as with `./deploy_che.sh --secure`) and deploy a Codewind workspace from the following devfile: https://github.com/johnmcollier/devfiles/blob/master/codewind/codewind_copy.yaml

To run the tests, cd into the `deploy-pfe` folder of this branch and run `make test`