### PR TITLE
Fix the Codewind performance dashboard in Che

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/deploy_test.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/deploy_test.go
@@ -265,13 +265,13 @@ func TestVerifyPFEEnvVars(t *testing.T) {
 			// Verify that KUBE_NAMESPACE and TILLER_NAMESPACE matches the namespace that codewind is deployed in
 			if env.Name == "KUBE_NAMESPACE" {
 				if env.Value != pfeDeploy.GetNamespace() {
-					t.Errorf("KUBE_NAMESPACE doesn't match the namespace that Codewind is deployed in %v\n", performanceService.GetName())
+					t.Errorf("KUBE_NAMESPACE doesn't match the namespace that Codewind is deployed in %v\n", pfeDeploy.GetNamespace())
 				}
 				continue
 			}
 			if env.Name == "TILLER_NAMESPACE" {
 				if env.Value != pfeDeploy.GetNamespace() {
-					t.Errorf("TILLER_NAMESPACE doesn't match Performance Dashboard service name: %v\n", performanceService.GetName())
+					t.Errorf("TILLER_NAMESPACE doesn't match Performance Dashboard service name: %v\n", pfeDeploy.GetNamespace())
 				}
 				continue
 			}
@@ -279,7 +279,7 @@ func TestVerifyPFEEnvVars(t *testing.T) {
 			// Verify that SERVICE_ACCOUNT_NAME matches the service account that Codewind-PFE is running in
 			if env.Name == "SERVICE_ACCOUNT_NAME" {
 				if env.Value != pfeDeploy.Spec.Template.Spec.ServiceAccountName {
-					t.Errorf("SERVICE_ACCOUNT_NAME doesn't match Codewind-PFE service account name: %v\n", performanceService.GetName())
+					t.Errorf("SERVICE_ACCOUNT_NAME doesn't match Codewind-PFE service account name: %v\n", pfeDeploy.Spec.Template.Spec.ServiceAccountName)
 				}
 				continue
 			}
@@ -287,7 +287,7 @@ func TestVerifyPFEEnvVars(t *testing.T) {
 			// Verify that SERVICE_NAME matches the Codewind-PFE service name
 			if env.Name == "SERVICE_NAME" {
 				if env.Value != pfeService.GetName() {
-					t.Errorf("SERVICE_NAME doesn't match PFE service name: %v\n", performanceService.GetName())
+					t.Errorf("SERVICE_NAME doesn't match PFE service name: %v\n", pfeService.GetName())
 				}
 				continue
 			}

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -100,7 +100,7 @@ func setPFEEnvVars(codewind Codewind) []corev1.EnvVar {
 		},
 		{
 			Name:  "CODEWIND_PERFORMANCE_SERVICE",
-			Value: codewind.PerformanceName + "-" + codewind.WorkspaceID,
+			Value: constants.PerformancePrefix + "-" + codewind.WorkspaceID,
 		},
 		{
 			Name:  "CHE_INGRESS_HOST",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
- Fixes a bug preventing the Codewind performance dashboard from being accessed in Che
- Adds unit tests for the Codewind-PFE environment variables that rely on specific settings (such as service account name, namespace, etc)

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/217

### Does this PR require updates to the docs?
N/A

### How can this PR be tested?
1. Deploy a Codewind workspace using this [devfile](https://raw.githubusercontent.com/johnmcollier/devfiles/master/codewind/codewind_perfdb.yaml)
2. Create a NodeJS project in Codewind and let it deploy
3. Right click on the project and select `Open Performance Dashboard`