### PR TITLE
Fix the role needed to list the Tekton service

### DIFF
--- a/setup/install_che/codewind-tektonrole.yaml
+++ b/setup/install_che/codewind-tektonrole.yaml
@@ -16,4 +16,4 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["services"]
-  verbs: ["get", "list", "create", "delete", "patch"]
+  verbs: ["get", "list"]


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the `codewind-tekton` clusterrole we create so that it has the proper roles needed to retrieve the service / cluster-ip of the Tekton dashboard.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/289

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
1. Install the `latest` version of Codewind on Che
2. Install Tekton and the Tekton dashboard into `tekton-pipelines`
3. Apply the tekton role and rolebinding
4. Ensure the tekton dashboard can be accessed from within Codewind.