### PR TITLE
Update install.sh script for Che 7.0.0

### DIFF
--- a/setup/install_che/install.sh
+++ b/setup/install_che/install.sh
@@ -70,12 +70,11 @@ elif [[ "$INSTALL_MODE" == "os" ]]; then
     oc adm policy add-scc-to-group anyuid system:serviceaccounts:eclipse-che
 
     # Install Che using the openshift deployment scripts
-    git clone https://github.com/eclipse/che.git
+    git clone -b 7.0.x https://github.com/eclipse/che.git
     cd che/deploy/openshift
     
-    echo 'os'
     # Deploy on OpenShift
-    ./deploy_che.sh --image-che=eclipse/che-server:7.0.0-RC-2.0
+    ./deploy_che.sh --image-che=eclipse/che-server:7.0.0
 
     # Create the role binding
     kubectl apply -f ${BASE_DIR}/codewind-rolebinding.yaml -n eclipse-che
@@ -88,7 +87,7 @@ else
     fi
 
     # Clone the Che repositor, as that's where the Che helm chart resides
-    git clone -b 7.0.0-RC-2.x https://github.com/eclipse/che.git
+    git clone -b 7.0.x https://github.com/eclipse/che.git
     cd che/deploy/kubernetes/helm/che
 
     # Install Helm dependencies
@@ -96,7 +95,7 @@ else
 
     # Install Che helm chart
     helm upgrade --install che --namespace $CHE_NAMESPACE \
-        --set cheImage=eclipse/che-server:7.0.0-RC-2.0 \
+        --set cheImage=eclipse/che-server:7.0.0 \
         --set global.ingressDomain=$INGRESS_DOMAIN \
         --set global.cheWorkspacesNamespace=$CHE_NAMESPACE \
         --set global.cheWorkspaceClusterRole=eclipse-codewind \


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the install.sh script for the Codewind-ready install of Che to use the Che 7.0.0 GA images rather than RC2.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
1. Git clone this branch
2. Run `setup/install_che/install.sh -m openshift` and verify Che 7.0.0 is installed.