### PR TITLE
Update 0.3.0 plugin version

### DIFF
--- a/plugins/codewind/codewind-sidecar/0.3.0/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/0.3.0/meta.yaml
@@ -11,7 +11,7 @@
 
 id: codewind-sidecar
 apiVersion: v2
-version: latest
+version: 0.3.0
 type: Che Plugin
 name: CodewindPlugin
 title: CodewindPlugin

--- a/plugins/codewind/codewind-theia/0.3.0/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.3.0/meta.yaml
@@ -12,7 +12,7 @@
 apiVersion: v2
 publisher: eclipse
 name: codewind-plugin
-version: latest
+version: 0.3.0
 type: VS Code extension
 displayName: Codewind VS Code Extension
 title: Codewind Extension for VS Code


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
The `0.3.0` Che plugins accidentally had their version set to `latest`, it should be `0.3.0` instead. This is a minor fix and doesn't affect anything functionally, but the version should be changed to avoid confusion.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A

### How can this PR be tested?
N/A