### PR TITLE
Always use newest version of 0.3 Codewind

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
@@ -16,10 +16,10 @@ const (
 	PerformanceImage = "eclipse/codewind-performance-amd64"
 
 	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
-	PFEImageTag = "0.3.0"
+	PFEImageTag = "0.3"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
-	PerformanceTag = "0.3.0"
+	PerformanceTag = "0.3"
 
 	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
 	ImagePullPolicy = corev1.PullAlways


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
This PR updates the 0.3.0 version of the Codewind Che Plugin to point to `0.3` tags of PFE and Performance Dashboard instead of `0.3.0`, so that updates are automatically picked up.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
Verify this [devfile](https://raw.githubusercontent.com/johnmcollier/devfiles/master/codewind/codewind_copy.yaml) can create a workspace and that the `0.3` tags are used for PFE and Performance Dashboard