### PR TITLE
Fix namespace for tekton binding

### DIFF
--- a/setup/install_che/codewind-tektonbinding.yaml
+++ b/setup/install_che/codewind-tektonbinding.yaml
@@ -14,7 +14,7 @@ metadata:
   name: codewind-tektonbinding
 subjects:
 - kind: ServiceAccount
-  namespace: eclipse-che
+  namespace: che
   name: che-workspace
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Now that we're recommending users install Che with `chectl`, Che is installed by it into the `che` namespace. So this PR updates the tekton rolebinding to be applied into that namespace.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:


### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 