### PR TITLE
Publish cumulative docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,16 @@ pipeline {
                             echo "Publishing docker images for Eclipse Codewind Che Sidecar..."
                             echo "publish.sh eclipse $TAG"
                             ./scripts/publish.sh eclipse $TAG
+
+                            if [[ $GIT_BRANCH =~ ^([0-9]+\\.[0-9]+) ]]; then
+                                IFS='.' # set '.' as delimiter
+                                read -ra TOKENS <<< "$GIT_BRANCH"    
+                                IFS=' ' # reset delimiter
+                                export TAG_CUMULATIVE=${TOKENS[0]}.${TOKENS[1]}
+
+                                echo "publish.sh eclipse $TAG_CUMULATIVE"
+                                ./scripts/publish.sh eclipse $TAG_CUMULATIVE                               
+                            fi
                         else
                             echo "Skip publishing docker images for $GIT_BRANCH branch"
                         fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
publish cumulative docker images during the release branch build.
e.g.
publish 0.5 and 0.5.0 docker images from 0.5.0 branch build.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:


### Does this PR require updates to the docs?
No

### How can this PR be tested?
Manually tested. 