### PR TITLE
Add environment variable to PFE if on OpenShift

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/main.go
+++ b/codewind-che-sidecar/deploy-pfe/main.go
@@ -81,6 +81,9 @@ func main() {
 	// Retrieve the images for PFE and Performance dashboard
 	pfe, performance := codewind.GetImages()
 
+	// Determine if we're running on OpenShift or not.
+	onOpenShift := kube.DetectOpenShift3(config)
+
 	// Create the Codewind deployment object
 	codewindInstance := codewind.Codewind{
 		PFEName:            constants.PFEPrefix + cheWorkspaceID,
@@ -96,6 +99,7 @@ func main() {
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,
 		Ingress:            constants.PFEPrefix + "-" + cheWorkspaceID + "-" + cheIngress,
+		OnOpenShift:        onOpenShift,
 	}
 
 	// Patch the Che workspace service account
@@ -112,9 +116,8 @@ func main() {
 	}
 
 	// Expose Codewind over an ingress or route
-	isOpenShift := kube.DetectOpenShift3(config)
-	if isOpenShift {
-		// Deploy a route instead on OpenShift 3.x
+	if onOpenShift {
+		// Deploy a route instead on OpenShift
 		route := codewind.CreateRoute(codewindInstance)
 		routev1client, err := routev1.NewForConfig(config)
 		if err != nil {

--- a/codewind-che-sidecar/deploy-pfe/main.go
+++ b/codewind-che-sidecar/deploy-pfe/main.go
@@ -82,7 +82,7 @@ func main() {
 	pfe, performance := codewind.GetImages()
 
 	// Determine if we're running on OpenShift or not.
-	onOpenShift := kube.DetectOpenShift3(config)
+	onOpenShift := kube.DetectOpenShift(config)
 
 	// Create the Codewind deployment object
 	codewindInstance := codewind.Codewind{

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/types.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/types.go
@@ -17,6 +17,7 @@ type Codewind struct {
 	OwnerReferenceUID  types.UID
 	Privileged         bool
 	Ingress            string
+	OnOpenShift        bool
 }
 
 // ServiceAccountPatch contains an array of imagePullSecrets that will be patched into a Kubernetes service account

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -3,6 +3,7 @@ package codewind
 import (
 	"encoding/json"
 	"os"
+	"strconv"
 
 	"deploy-pfe/pkg/constants"
 
@@ -105,6 +106,10 @@ func setPFEEnvVars(codewind Codewind) []corev1.EnvVar {
 		{
 			Name:  "CHE_INGRESS_HOST",
 			Value: codewind.Ingress,
+		},
+		{
+			Name:  "ON_OPENSHIFT",
+			Value: strconv.FormatBool(codewind.OnOpenShift),
 		},
 	}
 }

--- a/codewind-che-sidecar/deploy-pfe/pkg/kube/kube.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/kube/kube.go
@@ -31,9 +31,9 @@ func GetCurrentNamespace() string {
 	return namespace
 }
 
-// DetectOpenShift3 determines if we're running on an OpenShift 3.x cluster
+// DetectOpenShift determines if we're running on an OpenShift cluster
 // From https://github.com/eclipse/che-operator/blob/2f639261d8b5416b2934591e12925ee0935814dd/pkg/util/util.go#L63
-func DetectOpenShift3(config *rest.Config) bool {
+func DetectOpenShift(config *rest.Config) bool {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		log.Errorf("Unable to detect if running on OpenShift: %v\n", err)


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
To support the upcoming `odo` extension, this PR adds a `ON_OPENSHIFT` environment variable to PFE that's set to true if Codewind is deployed on an OpenShift cluster. This will enable us to ensure the odo extension is only enabled if we're on OpenShift.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
