### PR TITLE
Bind PFE PVC to Che workspace PVC

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/che/che.go
@@ -8,16 +8,14 @@ import (
 	"deploy-pfe/pkg/kube"
 
 	log "github.com/sirupsen/logrus"
-
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
 // GetWorkspacePVC retrieves the PVC (Persistent Volume Claim) associated with the Che workspace we're deploying Codewind in
-func GetWorkspacePVC(clientset *kubernetes.Clientset, namespace string, cheWorkspaceID string) string {
-	var pvcName string
-
+func GetWorkspacePVC(clientset *kubernetes.Clientset, namespace string, cheWorkspaceID string) *corev1.PersistentVolumeClaim {
 	PVCs, err := clientset.CoreV1().PersistentVolumeClaims(namespace).List(metav1.ListOptions{
 		LabelSelector: "che.workspace.volume_name=projects,che.workspace_id=" + cheWorkspaceID,
 	})
@@ -29,19 +27,14 @@ func GetWorkspacePVC(clientset *kubernetes.Clientset, namespace string, cheWorks
 		PVCs, err = clientset.CoreV1().PersistentVolumeClaims(namespace).List(metav1.ListOptions{
 			LabelSelector: "che.workspace_id=" + cheWorkspaceID,
 		})
-		if err != nil || PVCs == nil {
+		if err != nil || PVCs == nil || len(PVCs.Items) < 1 {
 			log.Errorf("Error, unable to retrieve PVCs: %v\n", err)
 			os.Exit(1)
-		} else if len(PVCs.Items) != 1 {
-			pvcName = "claim-che-workspace"
 		} else {
-			pvcName = PVCs.Items[0].GetName()
+			return &PVCs.Items[0]
 		}
-	} else {
-		pvcName = PVCs.Items[0].GetName()
 	}
-
-	return pvcName
+	return &PVCs.Items[0]
 }
 
 // GetWorkspaceServiceAccount retrieves the Service Account associated with the Che workspace we're deploying Codewind in

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -388,14 +388,14 @@ func CreateIngress(codewind Codewind) extensionsv1.Ingress {
 }
 
 // GeneratePVC creates a persistent volume claim for PFE
-func generatePVC(codewind Codewind, volumeSize string, storageClass string) corev1.PersistentVolumeClaim {
+func generatePVC(codewind Codewind, volumeSize string, storageClass string, wsPVCName string, wsPVCUID types.UID) corev1.PersistentVolumeClaim {
 	labels := map[string]string{
 		"app":               constants.PFEPrefix,
 		"codewindWorkspace": codewind.WorkspaceID,
 	}
 
 	blockOwnerDeletion := true
-	controller := true
+	controller := false
 
 	pvc := corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
@@ -407,12 +407,12 @@ func generatePVC(codewind Codewind, volumeSize string, storageClass string) core
 			Labels: labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         "apps/v1",
+					APIVersion:         "v1",
 					BlockOwnerDeletion: &blockOwnerDeletion,
 					Controller:         &controller,
-					Kind:               "ReplicaSet",
-					Name:               codewind.OwnerReferenceName,
-					UID:                codewind.OwnerReferenceUID,
+					Kind:               "PersistentVolumeClaim",
+					Name:               wsPVCName,
+					UID:                wsPVCUID,
 				},
 			},
 		},

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -49,8 +49,8 @@ rules:
   verbs: ["get", "list", "create", "update", "delete", "patch"]
 
 - apiGroups: [""]
-  resources: ["persistentvolumeclaims"]
-  verbs: ["delete", "create", "patch", "get", "list"]
+  resources: ["persistentvolumeclaims", "persistentvolumeclaims/finalizers", "persistentvolumeclaims/status"]
+  verbs: ["*"]
 
 - apiGroups: ["icp.ibm.com"]
   resources: ["images"]


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Ties the PFE persistent volume to the Che workspace persistent volume so that the volume doesn't get deleted before the Che workspace itself is deleted. This prevents the volume from going away if the workspace is paused/stopped, and prevents project metadata from being lost.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1018

### Does this PR require updates to the docs?
N/A