### PR TITLE
Add che ingress prefix to PFE

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/main.go
+++ b/codewind-che-sidecar/deploy-pfe/main.go
@@ -96,6 +96,7 @@ func main() {
 		Privileged:         true,
 		Ingress:            constants.PFEPrefix + "-" + cheWorkspaceID + "-" + cheIngress,
 		OnOpenShift:        onOpenShift,
+		CheIngress:         cheIngress,
 	}
 
 	// Patch the Che workspace service account

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/types.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/types.go
@@ -18,6 +18,7 @@ type Codewind struct {
 	Privileged         bool
 	Ingress            string
 	OnOpenShift        bool
+	CheIngress         string
 }
 
 // ServiceAccountPatch contains an array of imagePullSecrets that will be patched into a Kubernetes service account

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -112,6 +112,10 @@ func setPFEEnvVars(codewind Codewind) []corev1.EnvVar {
 			Name:  "ON_OPENSHIFT",
 			Value: strconv.FormatBool(codewind.OnOpenShift),
 		},
+		{
+			Name:  "CHE_INGRESS_PREFIX",
+			Value: codewind.CheIngress,
+		},
 	}
 }
 

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -113,7 +113,7 @@ func setPFEEnvVars(codewind Codewind) []corev1.EnvVar {
 			Value: strconv.FormatBool(codewind.OnOpenShift),
 		},
 		{
-			Name:  "CHE_INGRESS_PREFIX",
+			Name:  "INGRESS_PREFIX",
 			Value: codewind.CheIngress,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Adds a new environment variable to PFE that represents the shorter Che ingress domain prefix (something like `che-che.9.1.2.3.nip.io`). This will allow us to create shorter ingress domains, hopefully

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
Part 1 of fix for https://github.com/eclipse/codewind/issues/1034

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A