### PR TITLE
Point Codewind-Che-Sidecar to 0.6.0 PFE and Performance

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
@@ -16,13 +16,13 @@ const (
 	PerformanceImage = "eclipse/codewind-performance-amd64"
 
 	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
-	PFEImageTag = "0.6.0"
+	PFEImageTag = "0.6"
 
 	// PFEVolumeSize is the size of the volume to use for PFE
 	PFEVolumeSize = "1Gi"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
-	PerformanceTag = "0.6.0"
+	PerformanceTag = "0.6"
 
 	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
 	ImagePullPolicy = corev1.PullAlways

--- a/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/constants/defaults.go
@@ -16,13 +16,13 @@ const (
 	PerformanceImage = "eclipse/codewind-performance-amd64"
 
 	// PFEImageTag is the image tag associated with the docker image that's used for Codewind-PFE
-	PFEImageTag = "latest"
+	PFEImageTag = "0.6.0"
 
 	// PFEVolumeSize is the size of the volume to use for PFE
 	PFEVolumeSize = "1Gi"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
-	PerformanceTag = "latest"
+	PerformanceTag = "0.6.0"
 
 	// ImagePullPolicy is the pull policy used for all containers in Codewind, defaults to Always
 	ImagePullPolicy = corev1.PullAlways


### PR DESCRIPTION
Updates the 0.6.0 branch of the sidecar to point to the newly published 0.6.0 tag of PFE and Performance