### PR TITLE
Remove Che Secret Volume Mount & Remove Che SA Patching

### DIFF
--- a/codewind-che-sidecar/deploy-pfe/main.go
+++ b/codewind-che-sidecar/deploy-pfe/main.go
@@ -67,10 +67,6 @@ func main() {
 	serviceAccountName := che.GetWorkspaceServiceAccount(clientset, namespace, cheWorkspaceID)
 	log.Infof("Service Account: %s\n", serviceAccountName)
 
-	// Get the name of the secret containing the workspace's registry secrets
-	secretName := che.GetWorkspaceRegistrySecret(clientset, namespace, cheWorkspaceID)
-	log.Infof("Registry Secret: %s\n", secretName)
-
 	// Get the Owner reference name and uid
 	ownerReferenceName, ownerReferenceUID := che.GetOwnerReferences(clientset, namespace, cheWorkspaceID)
 
@@ -90,20 +86,12 @@ func main() {
 		Namespace:          namespace,
 		WorkspaceID:        cheWorkspaceID,
 		ServiceAccountName: serviceAccountName,
-		PullSecret:         secretName,
 		OwnerReferenceName: ownerReferenceName,
 		OwnerReferenceUID:  ownerReferenceUID,
 		Privileged:         true,
 		Ingress:            constants.PFEPrefix + "-" + cheWorkspaceID + "-" + cheIngress,
 		OnOpenShift:        onOpenShift,
 		CheIngress:         cheIngress,
-	}
-
-	// Patch the Che workspace service account
-	err = codewind.PatchServiceAccount(clientset, codewindInstance)
-	if err != nil {
-		log.Errorf("Error: Unable to patch Che workspace service account: %v\n", err)
-		os.Exit(1)
 	}
 
 	err = codewind.DeployCodewind(clientset, codewindInstance, namespace)

--- a/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
+++ b/codewind-che-sidecar/deploy-pfe/pkg/codewind/util.go
@@ -139,8 +139,6 @@ func setPerformanceEnvVars(codewind Codewind) []corev1.EnvVar {
 // setPFEVolumes returns the 3 volumes & corresponding volume mounts required by the PFE container:
 // project workspace, buildah volume, and the docker registry secret (the latter of which is optional)
 func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
-	secretMode := int32(511)
-	isOptional := true
 
 	volumes := []corev1.Volume{
 		{
@@ -154,16 +152,6 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 		{
 			Name: "buildah-volume",
 		},
-		{
-			Name: "registry-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &secretMode,
-					SecretName:  codewind.PullSecret,
-					Optional:    &isOptional,
-				},
-			},
-		},
 	}
 
 	volumeMounts := []corev1.VolumeMount{
@@ -175,10 +163,6 @@ func setPFEVolumes(codewind Codewind) ([]corev1.Volume, []corev1.VolumeMount) {
 		{
 			Name:      "buildah-volume",
 			MountPath: "/var/lib/containers",
-		},
-		{
-			Name:      "registry-secret",
-			MountPath: "/tmp/secret",
 		},
 	}
 

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -30,7 +30,11 @@ rules:
 
 - apiGroups: [""]
   resources: ["secrets"]
+<<<<<<< HEAD
   verbs: ["get", "list", "create", "watch", "delete", "patch", "update"]
+=======
+  verbs: ["get", "list", "create", "watch", "delete"]
+>>>>>>> Update RBAC for secret resource - delete
 
 - apiGroups: [""]
   resources: ["serviceaccounts"]

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -30,11 +30,7 @@ rules:
 
 - apiGroups: [""]
   resources: ["secrets"]
-<<<<<<< HEAD
   verbs: ["get", "list", "create", "watch", "delete", "patch", "update"]
-=======
-  verbs: ["get", "list", "create", "watch", "delete"]
->>>>>>> Update RBAC for secret resource - delete
 
 - apiGroups: [""]
   resources: ["serviceaccounts"]


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
- Updates role binding RBAC policy for Kube resource `secret` to have `delete`
- Removes the Che Secret Volume Mount from `/tmp/secret` in PFE
- Removes patching of Che Service Account

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/665

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
Apply the new role bindings and use the API suggested in https://github.com/eclipse/codewind/issues/665