### PR TITLE
Backport PR to switch to Che 7.3.1

### DIFF
--- a/devfiles/0.6.0/devfile.yaml
+++ b/devfiles/0.6.0/devfile.yaml
@@ -1,0 +1,26 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+---
+apiVersion: 1.0.0
+metadata:
+  name: codewind-che
+components:
+  - alias: theia-ide
+    type: cheEditor
+    id: eclipse/che-theia/7.3.1
+  - alias: codewind-sidecar
+    type: chePlugin
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.6.0/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+  - alias: codewind-theia
+    type: chePlugin
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.6.0/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+

--- a/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
@@ -1,0 +1,33 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+id: codewind-sidecar
+apiVersion: v2
+version: 0.6.0
+type: Che Plugin
+name: CodewindPlugin
+title: CodewindPlugin
+description: Enables iterative development and deployment in Che
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
+publisher: eclipse
+repository: https://github.com/eclipse/codewind-che-plugin
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-11-08"
+spec:
+  containers:
+  - name: codewind-che-sidecar
+    image: eclipse/codewind-che-sidecar:0.6.0
+    volumes:
+      - mountPath: "/projects"
+        name: projects
+    ports:
+      - exposedPort: 9090

--- a/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+++ b/plugins/codewind/codewind-theia/0.6.0/meta.yaml
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+apiVersion: v2
+publisher: eclipse
+name: codewind-plugin
+version: 0.6.0
+type: VS Code extension
+displayName: Codewind VS Code Extension
+title: Codewind Extension for VS Code
+description: Codewind Extension for Theia
+icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
+repository: http://github.com/eclipse/codewind-vscode/
+category: Other
+firstPublicationDate: "2019-05-30"
+latestUpdateDate: "2019-11-08"
+spec:
+  extensions:
+    - https://download.eclipse.org/codewind/codewind-vscode/0.6.0/latest/codewind-theia.vsix

--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -19,11 +19,11 @@ spec:
     # server image used in Che deployment
     cheImage: 'eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.2.0'
+    cheImageTag: '7.3.1'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.2.0'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.3.1'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.2.0'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.3.1'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -107,7 +107,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'eclipse/che-keycloak:7.2.0'
+    identityProviderImage: 'eclipse/che-keycloak:7.3.1'
   k8s:
     # your global ingress domain
     ingressDomain: ''


### PR DESCRIPTION
Backports https://github.com/eclipse/codewind-che-plugin/pull/107 to the 0.6.0 branch and adds the 0.6.0 plugins to the 0.6.0 release branch