### PR TITLE
Don't crash the sidecar if PFE fails to deploy

### DIFF
--- a/codewind-che-sidecar/scripts/entrypoint.sh
+++ b/codewind-che-sidecar/scripts/entrypoint.sh
@@ -27,8 +27,7 @@ deploy-pfe
 
 CWServiceName=$(deploy-pfe get-service)
 if [ -z $CWServiceName ]; then
-    echo "ERROR: The Codewind service was not found. Aborting..."
-    exit 1
+    echo "ERROR: The Codewind service was not found"
 fi
 
 echo "Codewind is now ready."
@@ -70,8 +69,8 @@ while sleep 10; do
     ps aux | grep filewatcherd | grep -q -v grep
     FILEWATCHERD_PROCESS_STATUS=$?
     if [ $NGINX_PROCESS_STATUS -ne 0 ]; then
-        echo "Nginx process failed"
-        exit 1
+        echo "Nginx process failed. Restarting..."
+        nginx -g "daemon on;"
     fi
     if [ $FILEWATCHERD_PROCESS_STATUS -ne 0 ]; then
         filewatcherd $CWServiceNameEndpoint "/usr/local/bin/cwctl" &

--- a/codewind-che-sidecar/scripts/entrypoint.sh
+++ b/codewind-che-sidecar/scripts/entrypoint.sh
@@ -49,18 +49,18 @@ nginx -g "daemon on;"
 status=$?
 if [ $status -ne 0 ]; then
     echo "Failed to start nginx: $status"
-    exit $status
+else
+    echo "Started nginx"
 fi
-echo "Started nginx"
 
 # Start filewatcherd process
 filewatcherd $CWServiceNameEndpoint "/usr/local/bin/cwctl" &
 status=$?
 if [ $status -ne 0 ]; then
     echo "Failed to start filewatcherd: $status"
-    exit $status
+else
+    echo "Started filewatcherd"
 fi
-echo "Started filewatcherd"
 
 # Monitor nginx and filewatcherd processes every 10 seconds, exit if any of the two fail
 while sleep 10; do


### PR DESCRIPTION
In order to onboard Codewind to the plugin registry, we need to ensure the Che workspace starts always, even if PFE fails to deploy. This is to ensure we can display the following messages to the user:


![image (3)](https://user-images.githubusercontent.com/6880023/68790663-b04ae680-0615-11ea-8efa-1bf123c3d226.png)

and 

![image (4)](https://user-images.githubusercontent.com/6880023/68790667-b3de6d80-0615-11ea-80b3-e03506e78337.png)

Currently, if PFE fails to deploy, the sidecar will crash and the Che workspace never starts. This PR updates the sidecar entrypoint to avoid exiting. 