### PR TITLE
Delete pre-existing workspaces via Che API in test automation

### DIFF
--- a/codewind-che-sidecar/tests/sidecarfvt.bats
+++ b/codewind-che-sidecar/tests/sidecarfvt.bats
@@ -63,6 +63,7 @@ teardown() {
 }
 
 @test "Codewind Sidecar Test 1: Create Che workspace from Codewind dev file" {
+    deleteExistingCodewindCheWorkspaces
     createCodewindCheWorkspace
 }
 


### PR DESCRIPTION
Signed-off-by: Len Theivendra <theivend@ca.ibm.com>

### What does this PR do?
Update sidecar test automation to delete pre-existing Codewind Che workspaces via Che API

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1234
