### PR TITLE
Add che limit workspace idle timeout

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -53,6 +53,7 @@ spec:
     # additional custom Che properties
     customCheProperties:
       CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
+      CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: "0"
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
### Description

Adding the `CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` flag to disable the workspace idling. This helps for our test automation specifically because the workspace idles and timesout which causes the tests to crash.

After adding the flag, the tests didn't idle out anymore and was able to finish.

Signed-off-by: ssh24 <sakib@ibm.com>