### PR TITLE
Set a timeout for workspace plugin broker

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -54,6 +54,7 @@ spec:
     customCheProperties:
       CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
       CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: "0"
+      CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN: "15"
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
So the workspace creation would time out and get restarted by Che. It's timing out because the download for the VS Code extension is taking a long time. This PR adds a default timeout value to the broker.

Signed-off-by: ssh24 <sakib@ibm.com>