### PR TITLE
Trigger sidecar builds when CLI and fwd are updated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,9 @@ pipeline {
     }
     
     triggers {	
-      issueCommentTrigger('trigger_build')	
+      issueCommentTrigger('trigger_build')
+      upstream(upstreamProjects: "Codewind/codewind-installer/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
+      upstream(upstreamProjects: "Codewind/codewind-filewatchers/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
     }
 
     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,7 @@ pipeline {
     
     triggers {	
       issueCommentTrigger('trigger_build')
-      upstream(upstreamProjects: "Codewind/codewind-installer/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
-      upstream(upstreamProjects: "Codewind/codewind-filewatchers/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
+      upstream(upstreamProjects: "Codewind/codewind-installer/${env.BRANCH_NAME}, Codewind/codewind-filewatchers/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
     }
 
     options {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the Jenkinsfile for this repo so that it triggers a jenkins build when the CLI and filewatcherd are updated, allowing the sidecar to consume the most up-to-date binaries without manually having to trigger a build

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1214

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
N/A