### PR TITLE
Fix sidecar tests kube namespace argument

### DIFF
--- a/codewind-che-sidecar/tests/cronjob-sidecar.sh
+++ b/codewind-che-sidecar/tests/cronjob-sidecar.sh
@@ -59,7 +59,7 @@ else
   exit 1
 fi
 
-export CHE_INGRESS_DOMAIN=che-$NAMESPACE.$CLUSTER_IP.nip.io
+export CHE_INGRESS_DOMAIN=$(kubectl get routes --selector=component=che -o jsonpath="{.items[0].spec.host}" 2>&1)
 export CHE_NAMESPACE=$NAMESPACE
 export CLUSTER_IP
 

--- a/codewind-che-sidecar/tests/sidecarfvt.bats
+++ b/codewind-che-sidecar/tests/sidecarfvt.bats
@@ -34,7 +34,7 @@ setup() {
     fi
 
     export CODEWIND_DEVFILE_URL=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml
-    export KUBE_NAMESPACE_ARG="-n $CHE_NAMESPACE"
+    export KUBE_NAMESPACE_ARG=${CHE_NAMESPACE}
 
     # Discover workspace ID written into temporary file during workspace creation
     if [ -f che_workspace_id.txt ]; then
@@ -44,13 +44,13 @@ setup() {
     fi
 
     # Discover workspace pod and sidecar full names based on workspace ID
-    export CHE_WORKSPACE_POD_FULLNAME=$(kubectl get pods -l che.original_name=che-workspace-pod --no-headers -o custom-columns=":metadata.name" $KUBE_NAMESPACE_ARG | grep $CHE_WORKSPACE_ID)
-    export SIDECAR_CONTAINER_FULLNAME=$(kubectl get pods $CHE_WORKSPACE_POD_FULLNAME -o jsonpath='{.spec.containers[*].name}' $KUBE_NAMESPACE_ARG | sed 's/ /\n/g' | grep ^codewind-che-sidecar)
+    export CHE_WORKSPACE_POD_FULLNAME=$(kubectl get pods -l che.original_name=che-workspace-pod --no-headers -o custom-columns=":metadata.name" -n $KUBE_NAMESPACE_ARG | grep $CHE_WORKSPACE_ID)
+    export SIDECAR_CONTAINER_FULLNAME=$(kubectl get pods $CHE_WORKSPACE_POD_FULLNAME -o jsonpath='{.spec.containers[*].name}' -n $KUBE_NAMESPACE_ARG | sed 's/ /\n/g' | grep ^codewind-che-sidecar)
 
     # Set up Che access token for multi-user Che environment
     CHE_USER="admin"
     CHE_PASS="admin"
-    KEYCLOAK_HOSTNAME=keycloak-"$CHE_NAMESPACE"."$CLUSTER_IP".nip.io
+    KEYCLOAK_HOSTNAME=$(kubectl get routes --selector=component=keycloak -o jsonpath="{.items[0].spec.host}" 2>&1)
     TOKEN_ENDPOINT="http://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token" 
     export CHE_ACCESS_TOKEN=$(curl -sSL --data "grant_type=password&client_id=che-public&username=${CHE_USER}&password=${CHE_PASS}" ${TOKEN_ENDPOINT} | jq -r '.access_token')
 }
@@ -64,4 +64,116 @@ teardown() {
 @test "Codewind Sidecar Test 1: Create Che workspace from Codewind dev file" {
     deleteExistingCodewindCheWorkspaces
     createCodewindCheWorkspace
+}
+
+@test "Codewind Sidecar Test 2: Verify Codewind workspace pod is running" {
+    # Check if pod has started, timeout after 10 minutes
+    endtime=$(($SECONDS + 600))
+    pod_running=false
+    while (( $SECONDS < $endtime )); do
+        run getCodewindPod
+        if [[ $output = *"Running"* ]]; then
+            pod_running=true
+            break
+        fi
+        if [[ $output = *"Failure"* || $output = *"Unknown"* || $output = *"ImagePullBackOff"* || $output = *"CrashLoopBackOff"* || $output = *"PostStartHookError"* ]]; then
+            echo "# Error: Codewind pod failed to start" >&3
+            exit 1
+        fi
+    
+        sleep 2
+    done
+    
+    [ $pod_running = "true" ]
+}
+
+@test "Codewind Sidecar Test 3: Verify sidecar container is running and ready, and Codewind service successfully deployed" {
+    # Check if sidecar main processes have started after codewind server deployment, timeout after 10 minutes
+    endtime=$(($SECONDS + 600))
+    nginx_process_running=false
+    filewatcherd_process_running=false
+    while (( $SECONDS < $endtime )); do
+        run getPIDofProcessInContainer $CHE_WORKSPACE_POD_FULLNAME $SIDECAR_CONTAINER_FULLNAME nginx
+        if [ "$status" -eq 0 ]; then
+            nginx_process_running=true
+        fi
+
+        run getPIDofProcessInContainer $CHE_WORKSPACE_POD_FULLNAME $SIDECAR_CONTAINER_FULLNAME filewatcherd
+        if [ "$status" -eq 0 ]; then
+            filewatcherd_process_running=true
+        fi
+
+        if [[ $nginx_process_running = "true" && $filewatcherd_process_running = "true" ]]; then
+            break
+        fi
+
+        sleep 2
+    done
+
+    [ $nginx_process_running = "true" ]
+    [ $filewatcherd_process_running = "true" ]
+
+    # Allow some more time for sidecar container to settle
+    sleep 30
+
+    checkSidecarContainerReady
+
+    cw_service_name=$(kubectl get svc --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath="{.items[0].metadata.name}" -n $KUBE_NAMESPACE_ARG)
+    [ ! -z "$cw_service_name" ]
+}
+
+@test "Codewind Sidecar Test 4: Verify filewatcher daemon is up & running" {
+    # Check that the filewatcher daemon properly started, timeout after 2 minutes
+    endtime=$(($SECONDS + 120))
+    filewatcherd_ready=false
+    while (( $SECONDS < $endtime )); do
+        run checkFilewatcherDaemonRunning
+        if [ "$status" -eq 0 ]; then 
+            filewatcherd_ready=true
+            break
+        fi
+    done
+
+    [ $filewatcherd_ready = "true" ]
+}
+
+@test "Codewind Sidecar Test 5: Verify filewatcher daemon restarts after kill" {
+    time_before_kill=$SECONDS
+
+    # Kill filewatcherd process in the sidecar container
+    fwd_pid=$(getPIDofProcessInContainer $CHE_WORKSPACE_POD_FULLNAME $SIDECAR_CONTAINER_FULLNAME filewatcherd)
+    kubectl exec -t $CHE_WORKSPACE_POD_FULLNAME -n $KUBE_NAMESPACE_ARG --container $SIDECAR_CONTAINER_FULLNAME -- kill $fwd_pid
+
+    # Check every 5 seconds if filewatcherd has restarted, timeout after 5 minutes
+    endtime=$(($SECONDS + 300))
+    fwd_restarted=false
+    while (( $SECONDS < $endtime )); do
+        sleep 5
+        run getFileWatcherDaemonProcess
+        if [ "$status" -eq 0 ]; then
+            fwd_restarted=true
+            break
+        fi
+    done
+        
+    [ $fwd_restarted = "true" ]
+
+    # Allow some time for filewatcherd to settle
+    sleep 10
+
+    # Calculate approx time elapsed (in seconds) between filewatcher daemon kill and restart so as to only check the logs during that time
+    time_elapsed="$(($SECONDS - $time_before_kill))"
+
+    # Check if the filewatcher daemon started properly
+    checkFilewatcherDaemonRunning "$time_elapsed"
+}
+
+@test "Codewind Sidecar Test 6: Stop and delete the Codewind Che workspace" {
+    # Delete temporary file housing the workspace ID
+    if [ -f che_workspace_id.txt ]; then
+        rm che_workspace_id.txt
+    fi
+
+    stopCodewindCheWorkspace
+    deleteCodewindCheWorkspace
 }

--- a/codewind-che-sidecar/tests/sidecarfvt.bats
+++ b/codewind-che-sidecar/tests/sidecarfvt.bats
@@ -18,8 +18,6 @@ load testutil
 setup() {
     export time_before=$SECONDS
 
-    echo "INGRESS DOMAIN IS: $CHE_INGRESS_DOMAIN"
-
     if [ -z "$CHE_INGRESS_DOMAIN" ]; then
         echo "# Che ingress domain is not defined in " '$CHE_INGRESS_DOMAIN' >&3
         exit 1
@@ -36,10 +34,7 @@ setup() {
     fi
 
     export CODEWIND_DEVFILE_URL=https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/devfiles/latest/devfile.yaml
-    export CHE_INGRESS_DOMAIN_URL=http://$CHE_INGRESS_DOMAIN
     export KUBE_NAMESPACE_ARG="-n $CHE_NAMESPACE"
-
-    echo "INGRESS DOMAIN URL IS: $CHE_INGRESS_DOMAIN_URL"
 
     # Discover workspace ID written into temporary file during workspace creation
     if [ -f che_workspace_id.txt ]; then

--- a/codewind-che-sidecar/tests/testutil.bash
+++ b/codewind-che-sidecar/tests/testutil.bash
@@ -24,6 +24,9 @@ function createCodewindCheWorkspace() {
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
+    echo ">> HTTP response is: $HTTP_RESPONSE"
+    echo "\n>> HTTP STATUS is: $HTTP_STATUS"
+
     if [[ $HTTP_STATUS != 201 ]]; then
         echo "# Error creating Che Codewind workspace [HTTP status: $HTTP_STATUS]" >&3
         exit 1

--- a/codewind-che-sidecar/tests/testutil.bash
+++ b/codewind-che-sidecar/tests/testutil.bash
@@ -19,7 +19,7 @@ function createCodewindCheWorkspace() {
     fi
 
     # Create Che workspace based on latest Codewind .yaml devfile converted to json
-    local HTTP_RESPONSE=$(curl $CODEWIND_DEVFILE_URL | curl --silent --write-out "HTTPSTATUS:%{http_code}" --request POST --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --header "Content-Type:text/yaml" --data-binary @- $CHE_INGRESS_DOMAIN_URL/api/workspace/devfile?start-after-create=true)
+    local HTTP_RESPONSE=$(curl $CODEWIND_DEVFILE_URL | curl --silent --write-out "HTTPSTATUS:%{http_code}" --request POST --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --header "Content-Type:text/yaml" --data-binary @- $CHE_INGRESS_DOMAIN/api/workspace/devfile?start-after-create=true)
 
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -38,7 +38,7 @@ function createCodewindCheWorkspace() {
 
 # Stop the Codewind Che workspace
 function stopCodewindCheWorkspace() {
-    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN_URL/api/workspace/$CHE_WORKSPACE_ID/runtime)
+    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID/runtime)
 
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -54,7 +54,7 @@ function stopCodewindCheWorkspace() {
 
 # Delete the Codewind Che workspace
 function deleteCodewindCheWorkspace() {
-   local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN_URL/api/workspace/$CHE_WORKSPACE_ID)
+   local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID)
 
    local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
    local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -68,7 +68,7 @@ function deleteCodewindCheWorkspace() {
 # Delete any existing Codewind Che workspaces
 function deleteExistingCodewindCheWorkspaces() {
     # Get all Che Workspace IDs
-    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request GET $CHE_INGRESS_DOMAIN_URL/api/workspace)
+    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request GET $CHE_INGRESS_DOMAIN/api/workspace)
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -80,7 +80,7 @@ function deleteExistingCodewindCheWorkspaces() {
 
             # Stop the Codewind Workspace
             echo -e "# ${BLUE}Stopping the Codewind Workspace ${RESET}\n" >&3
-            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN_URL/api/workspace/${i}/runtime 2>/dev/null | head -n 1 | cut -d$' ' -f2)
+            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i}/runtime 2>/dev/null | head -n 1 | cut -d$' ' -f2)
             if [[ $HTTPSTATUS -ne 204 ]]; then
                 echo -e "# ${RED}Codewind workspace has failed to stop or is already stopped. Will attempt to remove the workspace... ${RESET}\n" >&3
             fi
@@ -90,7 +90,7 @@ function deleteExistingCodewindCheWorkspaces() {
 
             # Remove the Codewind Workspace
             echo -e "# ${BLUE}Removing the Codewind Workspace ${RESET}\n" >&3
-            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN_URL/api/workspace/${i} 2>/dev/null | head -n 1 | cut -d$' ' -f2)
+            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i} 2>/dev/null | head -n 1 | cut -d$' ' -f2)
             if [[ $HTTPSTATUS -ne 204 ]]; then
                 echo -e "# ${RED}Codewind workspace has failed to be removed... ${RESET}\n" >&3
                 exit 1


### PR DESCRIPTION
### Description

The issue was with initializing the entire namespace like `export KUBE_NAMESPACE_ARG="-n $CHE_NAMESPACE"`. This caused the `-n` to be thought of as a string and the kubectl command thought of it as a string parameter rather than an argument to the namespace. This was fixed by only have the namespace as the string and adding `-n` to the kubectl command as needed.

For example:
```
kubectl get pods --selector=app=codewind-pfe --no-headers -n $KUBE_NAMESPACE_ARG | grep $CHE_WORKSPACE_ID
```

Closes https://github.com/eclipse/codewind/issues/1615


Test result:
```
1..6
# Test time taken:  4  seconds
ok 1 Codewind Sidecar Test 1: Create Che workspace from Codewind dev file
# Test time taken:  122  seconds
ok 2 Codewind Sidecar Test 2: Verify Codewind workspace pod is running
# Test time taken:  38  seconds
ok 3 Codewind Sidecar Test 3: Verify sidecar container is running and ready, and Codewind service successfully deployed
# Test time taken:  4  seconds
ok 4 Codewind Sidecar Test 4: Verify filewatcher daemon is up & running
# Test time taken:  31  seconds
ok 5 Codewind Sidecar Test 5: Verify filewatcher daemon restarts after kill
# Test time taken:  34  seconds
ok 6 Codewind Sidecar Test 6: Stop and delete the Codewind Che workspace
```