### PR TITLE
Update for Che 7.6.0

### DIFF
--- a/devfiles/latest/devfile.yaml
+++ b/devfiles/latest/devfile.yaml
@@ -20,10 +20,10 @@ components:
     memoryLimit: 1024Mi
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/latest/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/latest/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/latest/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/latest/meta.yaml
   - alias: node-plugin
     type: chePlugin
     id: che-incubator/typescript/latest

--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -19,11 +19,11 @@ spec:
     # server image used in Che deployment
     cheImage: 'eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.3.1'
+    cheImageTag: '7.6.0'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.3.1'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.6.0'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.3.1'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.6.0'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -109,7 +109,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'eclipse/che-keycloak:7.3.1'
+    identityProviderImage: 'eclipse/che-keycloak:7.6.0'
   k8s:
     # your global ingress domain
     ingressDomain: ''


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the devfiles and CheCluster yaml for Che 7.6.0.

A side effect of moving from Che 7.3.1 to 7.6.0 is that we had to change references of `id: https://<some-link-to-codewind-plugin>` to `reference: https://<some-link-to-codewind-plugin>`. I've verified that this change doesn't break support for older Che's (like Che 7.3.1). This change is not required for plugins that are in the Che plugin registry.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A