### PR TITLE
Update Che plugins for Che 7.6.0

### DIFF
--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -9,12 +9,11 @@
 #     IBM Corporation - initial API and implementation
 ################################################################################
 
-id: codewind-sidecar
 apiVersion: v2
 version: latest
 type: Che Plugin
-name: CodewindPlugin
-title: CodewindPlugin
+name: codewind-sidecar
+title: Codewind Che Sidecar
 description: Enables iterative development and deployment in Che
 icon: https://raw.githubusercontent.com/eclipse/codewind-vscode/master/dev/res/img/codewind.png
 publisher: eclipse

--- a/plugins/codewind/codewind-theia/latest/meta.yaml
+++ b/plugins/codewind/codewind-theia/latest/meta.yaml
@@ -11,7 +11,7 @@
 
 apiVersion: v2
 publisher: eclipse
-name: codewind-plugin
+name: codewind-theia
 version: latest
 type: VS Code extension
 displayName: Codewind VS Code Extension


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the Che plugins for Che 7.6.0 compatibility.

Starting in Che 7.6.0 it appears it made it mandatory that the plugin alias in the devfile and the plugin name in the meta.yaml have to match. For whatever reason this did not appear in my testing yesterday (perhaps I had an older 7.6.0 build?)

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
N/A