### PR TITLE
Move down to Che 7.5.1

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -19,11 +19,11 @@ spec:
     # server image used in Che deployment
     cheImage: 'eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.6.0'
+    cheImageTag: '7.5.1'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.6.0'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.5.1'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.6.0'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.5.1'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -109,7 +109,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'eclipse/che-keycloak:7.6.0'
+    identityProviderImage: 'eclipse/che-keycloak:7.5.1'
   k8s:
     # your global ingress domain
     ingressDomain: ''


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Since there appears to be some issues with Theia plugins and CSS on Che 7.6.0 (see https://github.com/eclipse/che/issues/15635), I've moved the CheCluster yaml in this repo down to Che 7.5.1, which does not have those issues.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A