### PR TITLE
Fix ODO roles on che setup script

### DIFF
--- a/scripts/che-setup.sh
+++ b/scripts/che-setup.sh
@@ -303,12 +303,18 @@ echo -e "${CYAN}> Applying tekton role binding${RESET}"
 kubectl apply -f "$CODEWIND_CHE/setup/install_che/codewind-tektonbinding.yaml" -n $CHE_NS > /dev/null 2>&1
 displayMsg $? "Failed to apply tekton role binding." true
 
+cd "$CODEWIND_ODO_EXTENSION/setup"
+echo -e "${CYAN}> Performing setup before applying ODO roles${RESET}"
+./setup.sh > /dev/null 2>&1
+displayMsg $? "Failed to perform setup on ODO roles." true
+cd $CURR_DIR
+
 echo -e "${CYAN}> Applying kubectl ODO cluster role${RESET}"
 kubectl apply -f "$CODEWIND_ODO_EXTENSION/setup/codewind-odoclusterrole.yaml" -n $CHE_NS > /dev/null 2>&1
 displayMsg $? "Failed to apply kubectl ODO cluster role." true
 
 echo -e "${CYAN}> Applying kubectl ODO role binding${RESET}"
-kubectl apply -f "$CODEWIND_ODO_EXTENSION/setup/codewind-odoclusterrolebinding.yaml" -n $CHE_NS > /dev/null 2>&1
+kubectl apply -f "$CODEWIND_ODO_EXTENSION/setup/codewind-odorolebinding.yaml" -n $CHE_NS > /dev/null 2>&1
 displayMsg $? "Failed to apply kubectl ODO role binding." true
 
 echo -e "${CYAN}> Setting openshift admin policy: privileged ${RESET}"


### PR DESCRIPTION
### Description

The ODO latest version changed. The odo role binding name was changed and also now the setup script for ODO needs to be called to set the `serviceaccount` placeholder value. We need to adapt to it on the che setup script. This PR fixes it.

Signed-off-by: ssh24 <sakib@ibm.com>