### PR TITLE
Don't use che.original_name to get Che resources

### DIFF
--- a/codewind-che-sidecar/src/deploy-pfe/pkg/che/che.go
+++ b/codewind-che-sidecar/src/deploy-pfe/pkg/che/che.go
@@ -41,7 +41,7 @@ func GetWorkspaceServiceAccount(clientset *kubernetes.Clientset, namespace strin
 
 	// Retrieve the workspace service account labeled with the Che Workspace ID
 	workspacePod, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: "che.original_name=che-workspace-pod,che.workspace_id=" + cheWorkspaceID,
+		LabelSelector: "che.workspace_id=" + cheWorkspaceID,
 	})
 	if err != nil || workspacePod == nil {
 		log.Errorf("Error retrieving the Che workspace pod %v\n", err)
@@ -84,7 +84,7 @@ func GetOwnerReferences(clientset *kubernetes.Clientset, namespace string, cheWo
 	var ownerReferenceUID types.UID
 
 	workspacePod, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: "che.original_name=che-workspace-pod,che.workspace_id=" + cheWorkspaceID,
+		LabelSelector: "che.workspace_id=" + cheWorkspaceID,
 	})
 	if err != nil {
 		log.Errorf("Error: Unable to retrieve the workspace pod %v\n", err)

--- a/codewind-che-sidecar/src/deploy-pfe/pkg/che/che.go
+++ b/codewind-che-sidecar/src/deploy-pfe/pkg/che/che.go
@@ -57,25 +57,6 @@ func GetWorkspaceServiceAccount(clientset *kubernetes.Clientset, namespace strin
 
 }
 
-// GetWorkspaceRegistrySecret retrieves the Kubernetes ImagePullSecret associated with the Che workspace we're deploying Codewind in
-func GetWorkspaceRegistrySecret(clientset *kubernetes.Clientset, namespace string, cheWorkspaceID string) string {
-	var secretName string
-	// Retrieve the secret tagged with the workspace ID label
-	// If the secret is missing, fall back on a default value
-	registrySecret, err := clientset.CoreV1().Secrets(namespace).List(metav1.ListOptions{
-		LabelSelector: "che.workspace_id=" + cheWorkspaceID,
-	})
-	if err != nil {
-		log.Errorf("Error retrieving the list of secrets: %v\n", err)
-		os.Exit(1)
-	} else if len(registrySecret.Items) != 1 {
-		secretName = cheWorkspaceID + "-private-registries"
-	} else {
-		secretName = registrySecret.Items[0].GetName()
-	}
-	return secretName
-}
-
 // GetOwnerReferences retrieves the owner reference name and UID, allowing us to tie any Codewind resources to the Che workspace
 // Enabling the Kubernetes garbage collector clean everything up when the workspace is deleted
 func GetOwnerReferences(clientset *kubernetes.Clientset, namespace string, cheWorkspaceID string) (string, types.UID) {


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Fixes https://github.com/eclipse/codewind/issues/1750

When deploying Che from the Che plugin registry, `che.original_name` may not be set to `che-workspace-pod`, which may cause our lookups using that label to fail, and for Codewind not to get deployed. The solution instead is to just retrieve Che workspace resources with **only** the `che.workspace_id` label. 

Also, since `GetWorkspaceRegistrySecret` is no longer used (on account of us using our own registry secret), I've removed the function from the deploy code. 

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1750

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
N/A