### PR TITLE
Add devfile without LSPs

### DIFF
--- a/devfiles/0.8.0/devfile_nolsp.yaml
+++ b/devfiles/0.8.0/devfile_nolsp.yaml
@@ -1,0 +1,26 @@
+################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+################################################################################
+
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: codewind-che
+components:
+  - alias: theia-ide
+    type: cheEditor
+    id: eclipse/che-theia/latest
+    memoryLimit: 1024Mi
+  - alias: codewind-sidecar
+    type: chePlugin
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.8.0/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+  - alias: codewind-theia
+    type: chePlugin
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.8.0/plugins/codewind/codewind-theia/0.8.0/meta.yaml


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Creates an 0.8.0 devfile without the Java and Typescript LSPs included so that installs on Codeready workspaces don't fail without the same plugins.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A
