### PR TITLE
Take Test Cluster Port as an Env

### DIFF
--- a/codewind-che-sidecar/tests/cronjob-sidecar.sh
+++ b/codewind-che-sidecar/tests/cronjob-sidecar.sh
@@ -28,9 +28,16 @@ if [[ (-z $NAMESPACE) ]]; then
   echo -e "${RED}Please export variable NAMESPACE to run the Codewind sidecar tests. ${RESET}\n"
   exit 1
 fi
+
 if [[ (-z $CLUSTER_IP) ]]; then
   echo -e "${RED}Mandatory argument CLUSTER_IP is not set up. ${RESET}\n"
   echo -e "${RED}Please export variable CLUSTER_IP to run the Codewind sidecar tests. ${RESET}\n"
+  exit 1
+fi
+
+if [[ (-z $CLUSTER_PORT) ]]; then
+  echo -e "${RED}Mandatory argument CLUSTER_PORT is not set up. ${RESET}\n"
+  echo -e "${RED}Please export variable CLUSTER_PORT to run the Codewind sidecar tests. ${RESET}\n"
   exit 1
 fi
 
@@ -50,7 +57,7 @@ if [[ (-z $DASHBOARD_IP) ]]; then
   exit 1
 fi
 
-oc login $CLUSTER_IP:8443 -u $CLUSTER_USER -p $CLUSTER_PASSWORD
+oc login $CLUSTER_IP:$CLUSTER_PORT -u $CLUSTER_USER -p $CLUSTER_PASSWORD
 oc project $NAMESPACE
 if [[ $? -eq 0 ]]; then
   echo -e "${GREEN}Successfully logged into the OKD cluster ${RESET}\n"


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Removes the hardcoded test cluster port

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:


### Does this PR require updates to the docs?
N/A

### How can this PR be tested?
Run the test script with the necessary cluster credential info