### PR TITLE
Move up to Che 7.9.0

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -17,13 +17,13 @@ metadata:
 spec:
   server:
     # server image used in Che deployment
-    cheImage: 'eclipse/che-server'
+    cheImage: 'quay.io/eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.5.1'
+    cheImageTag: '7.9.0'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.5.1'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.9.0'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.5.1'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.9.0'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -32,9 +32,9 @@ spec:
     cheWorkspaceClusterRole: 'eclipse-codewind'
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
-    selfSignedCert: false
+    selfSignedCert: true
     # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
-    tlsSupport: false
+    tlsSupport: true
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
     # to Che server and workspaces containers
     proxyURL: ''
@@ -52,7 +52,7 @@ spec:
     serverMemoryLimit: ''
     # additional custom Che properties
     customCheProperties:
-      CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
+      CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "15"
       CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: "0"
       CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN: "15"
   database:
@@ -109,7 +109,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'eclipse/che-keycloak:7.5.1'
+    identityProviderImage: 'quay.io/eclipse/che-keycloak:7.9.0'
   k8s:
     # your global ingress domain
     ingressDomain: ''

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -74,7 +74,7 @@ metadata:
   name: eclipse-codewind
 subjects:
 - kind: ServiceAccount
-  name: codewind
+  name: che-workspace
 roleRef:
   kind: ClusterRole
   name: eclipse-codewind


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Updates the version of Che in our CheCluster yaml to Che 7.9.0. As versions of Che after 7.9.0 requires TLS to be enabled with Codewind, I've also set `tlsEnabled: true` and `selfSignedCert: true` in the yaml.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
Separate issue and PR will be opened for the HTTPS changes in Che.

### How can this PR be tested?
N/A