### PR TITLE
Allow Sidecar tests to run as https

### DIFF
--- a/codewind-che-sidecar/tests/cronjob-sidecar.sh
+++ b/codewind-che-sidecar/tests/cronjob-sidecar.sh
@@ -23,6 +23,13 @@ TEST_OUTPUT_DIR=~/test_results/sidecar/$DATE_NOW/$TIME_NOW
 TEST_OUTPUT_TAP=$TEST_OUTPUT_DIR/test_output.tap
 TEST_OUTPUT_XML=$TEST_OUTPUT_DIR/test_output.xml
 
+# Colors for success and error messages
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BLUE='\033[0;36m'
+YELLOW='\e[33m'
+RESET='\033[0m'
+
 if [[ (-z $NAMESPACE) ]]; then
   echo -e "${RED}Mandatory argument NAMESPACE is not set up. ${RESET}\n"
   echo -e "${RED}Please export variable NAMESPACE to run the Codewind sidecar tests. ${RESET}\n"
@@ -52,9 +59,18 @@ if [[ (-z $CLUSTER_PASSWORD) ]]; then
   echo -e "${RED}Please export variable CLUSTER_PASSWORD to run the Codewind sidecar tests. ${RESET}\n"
   exit 1
 fi
+
 if [[ (-z $DASHBOARD_IP) ]]; then
   echo -e "${RED}Dashboard IP is required to upload test results. ${RESET}\n"
   exit 1
+fi
+
+if [[ (-z $DISABLE_SSL) ]]; then
+  PROTOCOL="https://"
+  echo -e "${BLUE}SSL enabled. ${RESET}\n"
+else
+  PROTOCOL="http://"
+  echo -e "${BLUE}SSL disabled. ${RESET}\n"
 fi
 
 oc login $CLUSTER_IP:$CLUSTER_PORT -u $CLUSTER_USER -p $CLUSTER_PASSWORD
@@ -66,9 +82,10 @@ else
   exit 1
 fi
 
-export CHE_INGRESS_DOMAIN=$(kubectl get routes --selector=component=che -o jsonpath="{.items[0].spec.host}" 2>&1)
+export CHE_INGRESS_DOMAIN="${PROTOCOL}$(kubectl get routes --selector=component=che -o jsonpath="{.items[0].spec.host}" 2>&1)"
 export CHE_NAMESPACE=$NAMESPACE
 export CLUSTER_IP
+export PROTOCOL
 
 rm -rf $CODEWIND_CHE_PLUGIN_DIR \
 && mkdir -p $TEST_OUTPUT_DIR \

--- a/codewind-che-sidecar/tests/sidecarfvt.bats
+++ b/codewind-che-sidecar/tests/sidecarfvt.bats
@@ -175,5 +175,11 @@ teardown() {
     fi
 
     stopCodewindCheWorkspace
+    run getCodewindPod
+    while [[ $output =~ "Terminating" ]];
+    do
+        sleep 5
+        run getCodewindPod
+    done
     deleteCodewindCheWorkspace
 }

--- a/codewind-che-sidecar/tests/sidecarfvt.bats
+++ b/codewind-che-sidecar/tests/sidecarfvt.bats
@@ -50,9 +50,9 @@ setup() {
     # Set up Che access token for multi-user Che environment
     CHE_USER="admin"
     CHE_PASS="admin"
-    KEYCLOAK_HOSTNAME=$(kubectl get routes --selector=component=keycloak -o jsonpath="{.items[0].spec.host}" 2>&1)
-    TOKEN_ENDPOINT="http://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token" 
-    export CHE_ACCESS_TOKEN=$(curl -sSL --data "grant_type=password&client_id=che-public&username=${CHE_USER}&password=${CHE_PASS}" ${TOKEN_ENDPOINT} | jq -r '.access_token')
+    KEYCLOAK_HOSTNAME="${PROTOCOL}$(kubectl get routes --selector=component=keycloak -o jsonpath="{.items[0].spec.host}" 2>&1)"
+    TOKEN_ENDPOINT="${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token" 
+    export CHE_ACCESS_TOKEN=$(curl -k -sSL --data "grant_type=password&client_id=che-public&username=${CHE_USER}&password=${CHE_PASS}" ${TOKEN_ENDPOINT} | jq -r '.access_token')
 }
 
 # Teardown code after each test

--- a/codewind-che-sidecar/tests/testutil.bash
+++ b/codewind-che-sidecar/tests/testutil.bash
@@ -19,7 +19,7 @@ function createCodewindCheWorkspace() {
     fi
 
     # Create Che workspace based on latest Codewind .yaml devfile converted to json
-    local HTTP_RESPONSE=$(curl $CODEWIND_DEVFILE_URL | curl --silent --write-out "HTTPSTATUS:%{http_code}" --request POST --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --header "Content-Type:text/yaml" --data-binary @- $CHE_INGRESS_DOMAIN/api/workspace/devfile?start-after-create=true)
+    local HTTP_RESPONSE=$(curl -k $CODEWIND_DEVFILE_URL | curl -k --silent --write-out "HTTPSTATUS:%{http_code}" --request POST --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --header "Content-Type:text/yaml" --data-binary @- $CHE_INGRESS_DOMAIN/api/workspace/devfile?start-after-create=true)
 
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -35,7 +35,7 @@ function createCodewindCheWorkspace() {
 
 # Stop the Codewind Che workspace
 function stopCodewindCheWorkspace() {
-    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID/runtime)
+    local HTTP_RESPONSE=$(curl -k --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID/runtime)
 
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -51,7 +51,7 @@ function stopCodewindCheWorkspace() {
 
 # Delete the Codewind Che workspace
 function deleteCodewindCheWorkspace() {
-   local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID)
+   local HTTP_RESPONSE=$(curl -k --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/$CHE_WORKSPACE_ID)
 
    local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
    local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
@@ -65,7 +65,7 @@ function deleteCodewindCheWorkspace() {
 # Delete any existing Codewind Che workspaces
 function deleteExistingCodewindCheWorkspaces() {
     # Get all Che Workspace IDs
-    local HTTP_RESPONSE=$(curl --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request GET $CHE_INGRESS_DOMAIN/api/workspace)
+    local HTTP_RESPONSE=$(curl -k --silent --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --write-out "HTTPSTATUS:%{http_code}" --request GET $CHE_INGRESS_DOMAIN/api/workspace)
     local HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
     local HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
@@ -77,7 +77,7 @@ function deleteExistingCodewindCheWorkspaces() {
 
             # Stop the Codewind Workspace
             echo -e "# ${BLUE}Stopping the Codewind Workspace ${RESET}\n" >&3
-            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i}/runtime 2>/dev/null | head -n 1 | cut -d$' ' -f2)
+            HTTPSTATUS=$(curl -k -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i}/runtime 2>/dev/null | head -n 1 | cut -d$' ' -f2)
             if [[ $HTTPSTATUS -ne 204 ]]; then
                 echo -e "# ${RED}Codewind workspace has failed to stop or is already stopped. Will attempt to remove the workspace... ${RESET}\n" >&3
             fi
@@ -87,7 +87,7 @@ function deleteExistingCodewindCheWorkspaces() {
 
             # Remove the Codewind Workspace
             echo -e "# ${BLUE}Removing the Codewind Workspace ${RESET}\n" >&3
-            HTTPSTATUS=$(curl -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i} 2>/dev/null | head -n 1 | cut -d$' ' -f2)
+            HTTPSTATUS=$(curl -k -I --header 'Authorization: Bearer '"$CHE_ACCESS_TOKEN"'' --request DELETE $CHE_INGRESS_DOMAIN/api/workspace/${i} 2>/dev/null | head -n 1 | cut -d$' ' -f2)
             if [[ $HTTPSTATUS -ne 204 ]]; then
                 echo -e "# ${RED}Codewind workspace has failed to be removed... ${RESET}\n" >&3
                 exit 1


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Run the sidecar tests as https/http

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2416

### Does this PR require updates to the docs?
Add a matching PR to [the docs repo](https://github.com/eclipse/codewind-docs) for doc updates and link that PR to this issue.
N/A

### How can this PR be tested?
Include steps to tell the reviewer how they can test this PR. 
`cronjob-sidecar.sh`