### PR TITLE
Increase default volume size to 5Gi

### DIFF
--- a/codewind-che-sidecar/src/deploy-pfe/pkg/constants/defaults.go
+++ b/codewind-che-sidecar/src/deploy-pfe/pkg/constants/defaults.go
@@ -19,7 +19,7 @@ const (
 	PFEImageTag = "latest"
 
 	// PFEVolumeSize is the size of the volume to use for PFE
-	PFEVolumeSize = "1Gi"
+	PFEVolumeSize = "5Gi"
 
 	// PerformanceTag is the image tag associated with the docker image that's used for the Performance dashboard
 	PerformanceTag = "latest"


### PR DESCRIPTION
Fixes eclipse/codewind#2441

Increases the default volume size provisioned for Codewind from 1Gi to 5Gi.

@elsony please review