### PR TITLE
Add INSECURE_KEYRING=true to theia environment

### DIFF
--- a/devfiles/latest/devfile.yaml
+++ b/devfiles/latest/devfile.yaml
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019, 2020 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -18,6 +18,9 @@ components:
     type: cheEditor
     id: eclipse/che-theia/latest
     memoryLimit: 1024Mi
+    env:
+      - name: INSECURE_KEYRING
+        value: "true"
   - alias: codewind-sidecar
     type: chePlugin
     reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/latest/meta.yaml


### PR DESCRIPTION
Signed-off-by: Tim Etchells <timetchells@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
adds `INSECURE_KEYRING=true` to the Theia container environment

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2597#issuecomment-608473168

### Does this PR require updates to the docs?
No

### How can this PR be tested?
Create a workspace from the devfile and add a registry secret