### PR TITLE
Add installation instructions to Codewind Che YAML

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -9,6 +9,11 @@
 #  Contributors:
 #    Red Hat, Inc. - initial API and implementation
 #    IBM - Codewind specific settings
+#
+#  Instructions:
+#    For instructions on installing Codewind for Eclipse Che using
+#    this codewind-checluster.yaml file, see
+#    https://www.eclipse.org/codewind/che-installinfo.html
 
 apiVersion: org.eclipse.che/v1
 kind: CheCluster


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?

Adds a link to the instructions for installing Codewind on Che to the top of the `codewind-checluster.yaml` file.
