### PR TITLE
Move up to Che 7.12.2

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -24,11 +24,11 @@ spec:
     # server image used in Che deployment
     cheImage: 'quay.io/eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.9.2'
+    cheImageTag: '7.12.2'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.9.2'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.12.2'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.9.2'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.12.2'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -114,7 +114,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'quay.io/eclipse/che-keycloak:7.9.2'
+    identityProviderImage: 'quay.io/eclipse/che-keycloak:7.12.2'
   k8s:
     # your global ingress domain
     ingressDomain: ''


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

<!-- Please review the following before submitting a PR:
Contributing Guide for the Codewind Che Plugin: https://github.com/eclipse/codewind-che-plugin/blob/master/CONTRIBUTING.md
Pull Request Policy: https://wiki.eclipse.org/Codewind_GitHub_Workflows#Making_a_pull_request
-->

### What does this PR do?
Moves up the version of Che on master to Che 7.12.2. highest version we can use til https://github.com/eclipse/codewind/issues/3064 is resolved.

### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

### Does this PR require updates to the docs?
N/A