### PR TITLE
[Backport to 0.14.1] Move Che version up to 7.16.1

### DIFF
--- a/setup/install_che/che-operator/codewind-checluster.yaml
+++ b/setup/install_che/che-operator/codewind-checluster.yaml
@@ -24,11 +24,11 @@ spec:
     # server image used in Che deployment
     cheImage: 'quay.io/eclipse/che-server'
     # tag of an image used in Che deployment
-    cheImageTag: '7.12.2'
+    cheImageTag: '7.16.1'
     # image:tag used in Devfile registry deployment
-    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.12.2'
+    devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:7.16.1'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.12.2'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:7.16.1'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
@@ -114,7 +114,7 @@ spec:
     # secret used in oAuthClient. Auto generated if left blank
     oAuthSecret: ''
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'quay.io/eclipse/che-keycloak:7.12.2'
+    identityProviderImage: 'quay.io/eclipse/che-keycloak:7.16.1'
   k8s:
     # your global ingress domain
     ingressDomain: ''


### PR DESCRIPTION
Backports https://github.com/eclipse/codewind-che-plugin/pull/191 to the 0.14.1 branch. Moves Che version up to 7.16.1